### PR TITLE
fix: CLI serve silently drops return values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-08
+
+### Fixed
+
+- `intpot serve --cli` now prints return values — tool functions were executing but silently dropping output because Typer commands require explicit `typer.echo()` calls. The CLI builder now wraps registered functions so return values are printed automatically.
+
 ## [0.4.0] - 2026-04-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "intpot"
-version = "0.4.0"
+version = "0.4.1"
 description = "Universal converter between CLI (Typer), MCP (FastMCP), and API (FastAPI) interfaces"
 readme = "README.md"
 license = "MIT"

--- a/src/intpot/__init__.py
+++ b/src/intpot/__init__.py
@@ -1,6 +1,6 @@
 """intpot - Universal converter between CLI, MCP, and API interfaces."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from intpot.converter import IntpotApp, inspect_app, load
 from intpot.runtime import App

--- a/src/intpot/runtime_builders.py
+++ b/src/intpot/runtime_builders.py
@@ -12,11 +12,23 @@ if TYPE_CHECKING:
 
 def build_typer_app(name: str, tools: list[RegisteredTool]) -> _typer.Typer:
     """Construct a Typer CLI app from registered tools."""
+    import functools
+
     import typer
 
     cli_app = typer.Typer(name=name, help=f"{name} — powered by intpot")
     for tool in tools:
-        cli_app.command(name=tool.info.name, help=tool.info.description)(tool.func)
+        # Wrap so return values are printed — plain functions return values,
+        # but Typer commands need explicit output via typer.echo().
+        fn = tool.func
+
+        @functools.wraps(fn)
+        def _cli_wrapper(*args: object, _fn: object = fn, **kwargs: object) -> None:
+            result = _fn(*args, **kwargs)  # type: ignore[operator]
+            if result is not None:
+                typer.echo(result)
+
+        cli_app.command(name=tool.info.name, help=tool.info.description)(_cli_wrapper)
     return cli_app
 
 


### PR DESCRIPTION
## Summary

- `intpot serve app.py --cli` was silently dropping return values — functions executed but produced no output
- The CLI builder now wraps registered functions with `typer.echo()` so return values are printed

## Before

```bash
$ intpot serve app.py --cli -- add 3 5
# (no output)
```

## After

```bash
$ intpot serve app.py --cli -- add 3 5
8
```

## Test plan

- [x] End-to-end: `add 3 5` → prints `8`
- [x] End-to-end: `greet Alice` → prints `Hello, Alice!`
- [x] End-to-end: `greet Alice --greeting Hey` → prints `Hey, Alice!`
- [x] `None` return values are not printed
- [x] Full test suite passes (141/142, 1 pre-existing failure)
- [x] Lint + format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)