### PR TITLE
Fix #34: app.tool() should support description parameter

### DIFF
--- a/src/intpot/runtime.py
+++ b/src/intpot/runtime.py
@@ -60,7 +60,9 @@ class App:
         """
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-            info = _build_tool_info(func, name_override=name, description_override=description)
+            info = _build_tool_info(
+                func, name_override=name, description_override=description
+            )
             self._tools.append(RegisteredTool(func=func, info=info))
             return func
 
@@ -150,7 +152,11 @@ def _build_tool_info(
 ) -> ToolInfo:
     """Build a ToolInfo from a plain Python function."""
     tool_name = name_override or func.__name__
-    description = description_override if description_override is not None else (inspect.getdoc(func) or "")
+    description = (
+        description_override
+        if description_override is not None
+        else (inspect.getdoc(func) or "")
+    )
     is_async = asyncio.iscoroutinefunction(func)
 
     # Extract parameters from signature + type hints

--- a/src/intpot/runtime.py
+++ b/src/intpot/runtime.py
@@ -50,16 +50,17 @@ class App:
         return f"App({self.name!r}, tools={count})"
 
     def tool(
-        self, *, name: str | None = None
+        self, *, name: str | None = None, description: str | None = None
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorator to register a function as a tool.
 
         Args:
             name: Override the tool name (defaults to function name).
+            description: Override the tool description (defaults to docstring).
         """
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-            info = _build_tool_info(func, name_override=name)
+            info = _build_tool_info(func, name_override=name, description_override=description)
             self._tools.append(RegisteredTool(func=func, info=info))
             return func
 
@@ -143,11 +144,11 @@ class App:
 
 
 def _build_tool_info(
-    func: Callable[..., Any], *, name_override: str | None = None
+    func: Callable[..., Any], *, name_override: str | None = None, description_override: str | None = None
 ) -> ToolInfo:
     """Build a ToolInfo from a plain Python function."""
     tool_name = name_override or func.__name__
-    description = inspect.getdoc(func) or ""
+    description = description_override if description_override is not None else (inspect.getdoc(func) or "")
     is_async = asyncio.iscoroutinefunction(func)
 
     # Extract parameters from signature + type hints

--- a/src/intpot/runtime.py
+++ b/src/intpot/runtime.py
@@ -129,8 +129,7 @@ class App:
             import uvicorn
         except ImportError:
             raise ModuleNotFoundError(
-                "uvicorn is required for API serving. "
-                "Install it with: pip install intpot[api]"
+                "uvicorn is required for API serving. Install it with: pip install intpot[api]"
             ) from None
 
         api_app = build_fastapi_app(self.name, self._tools)
@@ -151,11 +150,7 @@ def _build_tool_info(
 ) -> ToolInfo:
     """Build a ToolInfo from a plain Python function."""
     tool_name = name_override or func.__name__
-    description = (
-        description_override
-        if description_override is not None
-        else (inspect.getdoc(func) or "")
-    )
+    description = description_override if description_override is not None else (inspect.getdoc(func) or "")
     is_async = asyncio.iscoroutinefunction(func)
 
     # Extract parameters from signature + type hints

--- a/src/intpot/runtime.py
+++ b/src/intpot/runtime.py
@@ -144,11 +144,18 @@ class App:
 
 
 def _build_tool_info(
-    func: Callable[..., Any], *, name_override: str | None = None, description_override: str | None = None
+    func: Callable[..., Any],
+    *,
+    name_override: str | None = None,
+    description_override: str | None = None,
 ) -> ToolInfo:
     """Build a ToolInfo from a plain Python function."""
     tool_name = name_override or func.__name__
-    description = description_override if description_override is not None else (inspect.getdoc(func) or "")
+    description = (
+        description_override
+        if description_override is not None
+        else (inspect.getdoc(func) or "")
+    )
     is_async = asyncio.iscoroutinefunction(func)
 
     # Extract parameters from signature + type hints

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -222,3 +222,25 @@ def test_function_body_extracted():
     tool = app.tools[0]
     assert tool.function_body is not None
     assert "return a + b" in tool.function_body
+
+
+def test_tool_description_override():
+    app = App("test")
+
+    @app.tool(description="Custom description")
+    def add(a: int, b: int) -> int:
+        """Docstring description."""
+        return a + b
+
+    assert app._tools[0].info.description == "Custom description"
+
+
+def test_tool_description_falls_back_to_docstring():
+    app = App("test")
+
+    @app.tool()
+    def add(a: int, b: int) -> int:
+        """Docstring description."""
+        return a + b
+
+    assert app._tools[0].info.description == "Docstring description."


### PR DESCRIPTION
## Summary

Add an optional `description` parameter to `App.tool()` and `_build_tool_info()` so users can override the docstring-derived description via the decorator.

## Approach

1. Add a `description: str | None = None` parameter to the `tool()` method signature. 2. Pass the `description` value through to `_build_tool_info()` by adding a corresponding parameter there. 3. In `_build_tool_info()`, use the provided `description` if not None, otherwise fall back to `inspect.getdoc(func)` as before.

## Files Changed

- `src/intpot/runtime.py`

## Related Issue

Fixes #34

## Testing

Verified the change manually. Let me know if you'd like any additional tests or adjustments.
