### PR TITLE
fix: run async tools in CLI mode

### DIFF
--- a/src/intpot/runtime_builders.py
+++ b/src/intpot/runtime_builders.py
@@ -12,7 +12,9 @@ if TYPE_CHECKING:
 
 def build_typer_app(name: str, tools: list[RegisteredTool]) -> _typer.Typer:
     """Construct a Typer CLI app from registered tools."""
+    import asyncio
     import functools
+    import inspect
 
     import typer
 
@@ -25,6 +27,8 @@ def build_typer_app(name: str, tools: list[RegisteredTool]) -> _typer.Typer:
         @functools.wraps(fn)
         def _cli_wrapper(*args: object, _fn: object = fn, **kwargs: object) -> None:
             result = _fn(*args, **kwargs)  # type: ignore[operator]
+            if inspect.iscoroutine(result):
+                result = asyncio.run(result)
             if result is not None:
                 typer.echo(result)
 

--- a/tests/test_runtime_builders.py
+++ b/tests/test_runtime_builders.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typer.testing import CliRunner
+
 from intpot.runtime import App, RegisteredTool
 
 
@@ -57,3 +59,20 @@ def test_build_fastmcp_app():
 
     # FastMCP stores tools internally — check the name
     assert mcp_app.name == "test"
+
+
+def test_build_typer_app_runs_async_tool():
+    from intpot.runtime_builders import build_typer_app
+
+    app = App("async-app")
+
+    @app.tool()
+    async def greet(name: str) -> str:
+        return f"Hello, {name}!"
+
+    cli_app = build_typer_app("test", app._tools)
+
+    result = CliRunner().invoke(cli_app, ["World"])
+
+    assert result.exit_code == 0
+    assert "Hello, World!" in result.output


### PR DESCRIPTION
## Summary

Fixes #33.

`build_typer_app()` now executes coroutine results with `asyncio.run()` before printing command output. This keeps existing synchronous tools unchanged while allowing async `@app.tool()` functions to work in `intpot serve --cli` / runtime CLI mode.

Added a `CliRunner` regression test that registers an async tool, invokes the generated Typer app, and verifies the async return value is printed.

## Validation

- `ruff format src tests`
- `ruff check src tests`
- `pytest tests/test_runtime_builders.py -q`
- `pytest -q`
- `pyright src tests`
