### PR TITLE
release: v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ release assembles them here — run `make changelog-draft` to preview them.
 
 <!-- towncrier release notes start -->
 
+## [0.4.2] - 2026-08-08
+
+### Added
+
+- `@app.tool()` accepts a `description` argument to override the description that would
+  otherwise be derived from the function's docstring — useful when the docstring is
+  written for developers reading the code rather than for the agent calling the tool.
+  Thanks @itniuma2026 for a first contribution! ([#44](https://github.com/tugrulguner/intpot/pull/44))
+
+### Fixed
+
+- `async def` tools now actually run under `intpot serve --cli`. The CLI wrapper called
+  the function but never awaited it, so an async tool printed a coroutine repr instead of
+  its result; the coroutine is now run to completion before its return value is echoed.
+  Thanks @guyua9 for a first contribution! ([#45](https://github.com/tugrulguner/intpot/pull/45))
+- Converting a FastAPI app no longer collapses every parameter into a request body.
+  `Query`, `Header`, `Path`, and `Body` sources are now detected during inspection and
+  preserved in generated code, so a query parameter stays a query parameter instead of
+  becoming `Body(...)`. Thanks @MhussainD4772 for a first contribution! ([#47](https://github.com/tugrulguner/intpot/pull/47))
+
 ## [0.4.1] - 2026-04-08
 
 ### Fixed

--- a/changelog.d/44.added.md
+++ b/changelog.d/44.added.md
@@ -1,4 +1,0 @@
-`@app.tool()` accepts a `description` argument to override the description that would
-otherwise be derived from the function's docstring — useful when the docstring is
-written for developers reading the code rather than for the agent calling the tool.
-Thanks @itniuma2026 for a first contribution!

--- a/changelog.d/45.fixed.md
+++ b/changelog.d/45.fixed.md
@@ -1,4 +1,0 @@
-`async def` tools now actually run under `intpot serve --cli`. The CLI wrapper called
-the function but never awaited it, so an async tool printed a coroutine repr instead of
-its result; the coroutine is now run to completion before its return value is echoed.
-Thanks @guyua9 for a first contribution!

--- a/changelog.d/47.fixed.md
+++ b/changelog.d/47.fixed.md
@@ -1,4 +1,0 @@
-Converting a FastAPI app no longer collapses every parameter into a request body.
-`Query`, `Header`, `Path`, and `Body` sources are now detected during inspection and
-preserved in generated code, so a query parameter stays a query parameter instead of
-becoming `Body(...)`. Thanks @MhussainD4772 for a first contribution!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "intpot"
-version = "0.4.1"
+version = "0.4.2"
 description = "Universal converter between CLI (Typer), MCP (FastMCP), and API (FastAPI) interfaces"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -609,7 +609,7 @@ wheels = [
 
 [[package]]
 name = "intpot"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Cuts v0.4.2. First release using the tooling from #49 — two commands did the whole thing:

```bash
uv version 0.4.2   # pyproject.toml + uv.lock
make changelog     # assembled changelog.d/ into a dated section, deleted the fragments
```

## Contents

Three user-facing changes, all from first-time contributors:

| PR | Change | By |
|----|--------|-----|
| #44 | `@app.tool(description=...)` overrides the docstring-derived description | @itniuma2026 |
| #45 | `async def` tools now actually run under `intpot serve --cli` | @guyua9 |
| #47 | FastAPI `Query`/`Header`/`Path`/`Body` sources preserved through conversion | @MhussainD4772 |

## Compatibility

No breaking changes. Python 3.11–3.13, unchanged. `@app.tool()`'s new `description` argument is keyword-only with a `None` default, so existing decorators behave identically.

The one behavior change to be aware of is #47: generated FastAPI code now emits `Query(...)`/`Header(...)`/`Path(...)` where it previously emitted `Body(...)` for everything. That's a fix — the old output misrepresented the source app — but if you have committed generated code, regenerating it will produce a real diff.

## After merge

`git tag v0.4.2 && git push origin v0.4.2` triggers `release.yml`: both gates, then PyPI, then a GitHub Release built from the changelog section above.

Note this is also the first live exercise of that workflow — it couldn't be dry-run. PyPI is currently at 0.4.1; what's unreleased is the three merged PRs of work on main since that tag.
---

*Corrected after merge: this description originally said v0.4.1 "was tagged but never published, so PyPI is currently two releases behind." Both halves were wrong — v0.4.1 was published on 2026-04-08, and PyPI was level with the latest tag, not behind it. What lagged was main, not PyPI.*
