### PR TITLE
fix: make generated Typer commands print results and run async bodies

### DIFF
--- a/changelog.d/53.fixed.md
+++ b/changelog.d/53.fixed.md
@@ -1,0 +1,6 @@
+Generated Typer CLIs now print what their commands return. `intpot eject --to cli`
+emitted the preserved function body directly under `@app.command()`, and Typer discards
+return values, so the command computed its result and printed nothing — the same bug
+fixed for `intpot serve --cli` in 0.4.1, which never reached the code generator. Async
+tools are also fixed: the generated command was `async def`, which Typer never awaits,
+and now runs the body through `asyncio.run`.

--- a/src/intpot/core/generators/_render.py
+++ b/src/intpot/core/generators/_render.py
@@ -91,6 +91,20 @@ def _collect_extra_imports(tools: list[ToolInfo]) -> list[str]:
     return sorted(result)
 
 
+_EXCESS_BLANK_LINES = re.compile(r"\n{4,}")
+
+
+def _normalize_blank_lines(code: str) -> str:
+    """Collapse runs of more than two consecutive blank lines.
+
+    Templates branch on whether a tool has a preserved body, and the two
+    branches do not carry the same trailing whitespace. Normalising here keeps
+    every generator's output at PEP 8's two-blank-line maximum without spreading
+    whitespace-control tags through the templates.
+    """
+    return _EXCESS_BLANK_LINES.sub("\n\n\n", code)
+
+
 def render_template(template_name: str, **kwargs: object) -> str:
     env = Environment(
         loader=FileSystemLoader(str(_TEMPLATES_DIR)),
@@ -110,4 +124,4 @@ def render_template(template_name: str, **kwargs: object) -> str:
             if "extra_imports" not in kwargs:
                 kwargs = dict(kwargs, extra_imports=_collect_extra_imports(tools))
 
-    return template.render(**kwargs)
+    return _normalize_blank_lines(template.render(**kwargs))

--- a/src/intpot/templates/cli_app.py.j2
+++ b/src/intpot/templates/cli_app.py.j2
@@ -2,6 +2,10 @@
 {% if typing_imports %}
 from typing import {{ typing_imports | join(", ") }}
 {%- endif %}
+{%- set needs_asyncio = tools | selectattr("is_async") | selectattr("function_body") | list %}
+{%- if needs_asyncio %}
+import asyncio
+{% endif %}
 import typer
 {%- if extra_imports %}
 {% for imp in extra_imports %}
@@ -11,13 +15,23 @@ import typer
 
 app = typer.Typer()
 {% for tool in tools %}
+{%- if tool.function_body %}
+
+{% if tool.is_async %}async {% endif %}def _{{ tool.name }}_impl(
+{%- for param in tool.parameters %}
+    {{ param.name }}: {{ param.type_annotation }},
+{%- endfor %}
+) -> {{ tool.return_type }}:
+    """{{ tool.description | escape_doc }}"""
+    {{ tool.function_body | indent(4) }}
+{%- endif %}
 
 
 {% if tool.dependencies -%}
 # NOTE: Original used dependency injection: {{ tool.dependencies | join(", ") }}
 {% endif -%}
 @app.command()
-{% if tool.is_async %}async {% endif %}def {{ tool.name }}(
+def {{ tool.name }}(
 {%- for param in tool.parameters %}
     {{ param.name }}: {{ param.type_annotation }}
 {%- if not param.required %} = typer.Option({{ param.default | repr }}, help="{{ param.description | escape_doc }}")
@@ -26,14 +40,16 @@ app = typer.Typer()
 {%- endfor %}
 ) -> None:
     """{{ tool.description | escape_doc }}"""
-{% if tool.function_body %}
-    {{ tool.function_body | indent(4) }}
+{%- if tool.function_body %}
+{%- set call = "_" + tool.name + "_impl(" + (tool.parameters | map(attribute="name") | join(", ")) + ")" %}
+    result = {% if tool.is_async %}asyncio.run({{ call }}){% else %}{{ call }}{% endif %}
+    if result is not None:
+        typer.echo(result)
 {%- else %}
     # TODO: implement
     typer.echo("{{ tool.name }} called")
 {%- endif %}
-{%- endfor %}
-
+{% endfor %}
 
 if __name__ == "__main__":
     app()

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -170,7 +170,37 @@ class TestAsyncTools:
         for gen in _all_generators():
             code = gen.generate([tool])
             compile(code, "<string>", "exec")
-            assert "async def async_tool" in code
+
+    def test_async_tool_stays_async_for_mcp_and_api(self) -> None:
+        """MCP and FastAPI both await handlers, so the async marker is preserved."""
+        from intpot.core.generators.api import APIGenerator
+        from intpot.core.generators.mcp import MCPGenerator
+
+        tool = ToolInfo(name="async_tool", description="An async tool", is_async=True)
+
+        for gen in (MCPGenerator(), APIGenerator()):
+            assert "async def async_tool" in gen.generate([tool])
+
+    def test_async_command_is_not_emitted_for_cli(self) -> None:
+        """Typer cannot run an `async def` command — it would never be awaited.
+
+        The generated command stays synchronous; when a body is preserved it is
+        driven through asyncio.run instead.
+        """
+        from intpot.core.generators.cli import CLIGenerator
+
+        tool = ToolInfo(
+            name="async_tool",
+            description="An async tool",
+            is_async=True,
+            function_body="return 42",
+        )
+
+        code = CLIGenerator().generate([tool])
+
+        assert "async def _async_tool_impl(" in code
+        assert "asyncio.run(_async_tool_impl())" in code
+        assert "async def async_tool(" not in code
 
 
 class TestFunctionBody:

--- a/tests/test_generators/test_cli_generator.py
+++ b/tests/test_generators/test_cli_generator.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from typer.testing import CliRunner
+
 from intpot.core.generators.cli import CLIGenerator
 from intpot.core.models import _SENTINEL, ParameterInfo, ToolInfo
 
@@ -42,3 +46,73 @@ def test_generate_empty():
     code = CLIGenerator().generate([])
     assert "import typer" in code
     assert "app = typer.Typer()" in code
+
+
+def _run_generated(code: str, args: list[str]) -> Any:
+    """Execute generated CLI code and invoke it, returning the Typer result."""
+    namespace: dict[str, Any] = {}
+    exec(compile(code, "<generated>", "exec"), namespace)
+    return CliRunner().invoke(namespace["app"], args)
+
+
+def test_generated_cli_prints_the_return_value():
+    """Typer discards return values, so a preserved body needs an explicit echo."""
+    tools = [
+        ToolInfo(
+            name="add",
+            description="Add two numbers.",
+            parameters=[
+                ParameterInfo(name="a", type_annotation="int", default=_SENTINEL),
+                ParameterInfo(name="b", type_annotation="int", default=_SENTINEL),
+            ],
+            return_type="int",
+            function_body="return a + b",
+        ),
+    ]
+
+    result = _run_generated(CLIGenerator().generate(tools), ["2", "3"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "5"
+
+
+def test_generated_cli_runs_an_async_body():
+    """`async def` under @app.command() is never awaited, so the body is driven
+    through asyncio.run from a synchronous command instead."""
+    tools = [
+        ToolInfo(
+            name="fetch",
+            description="Fetch a URL.",
+            parameters=[
+                ParameterInfo(name="url", type_annotation="str", default=_SENTINEL),
+            ],
+            return_type="str",
+            is_async=True,
+            function_body='return f"fetched {url}"',
+        ),
+    ]
+
+    result = _run_generated(CLIGenerator().generate(tools), ["example.com"])
+
+    assert result.exit_code == 0
+    assert "fetched example.com" in result.output
+
+
+def test_generated_cli_stays_quiet_when_the_body_returns_nothing():
+    """A body that echoes itself must not also print a bare `None`."""
+    tools = [
+        ToolInfo(
+            name="log",
+            description="Log a message.",
+            parameters=[
+                ParameterInfo(name="msg", type_annotation="str", default=_SENTINEL),
+            ],
+            return_type="None",
+            function_body="typer.echo(msg)",
+        ),
+    ]
+
+    result = _run_generated(CLIGenerator().generate(tools), ["hello"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "hello"


### PR DESCRIPTION
## The bugs

Two, both in `cli_app.py.j2`, and both are the generated-code twin of runtime bugs already fixed on the `serve` path.

**1. Output is silently dropped.** Using the README's own example:

```
$ intpot eject demo.py --to cli --output ejected.py
$ python ejected.py add 2 3
$                       # nothing. exit code 0.
```

The template emitted the preserved body straight under `@app.command()`, so `return a + b` computed `5` and Typer discarded it. **This is the v0.4.1 bug.** That fix went into the runtime wrapper in `runtime_builders.py`; the template that generates standalone code never got it.

**2. Async tools can't run at all.** The template emitted `async def` under `@app.command()`. Typer doesn't await commands, so it got a coroutine and did nothing.

## The fix

The body moves into a module-level `_<name>_impl` carrying the tool's real signature and return type. The command calls it and echoes any non-`None` result, through `asyncio.run` when the tool is async:

```python
def _add_impl(a: int, b: int) -> int:
    """Add two numbers."""
    return a + b


@app.command()
def add(
    a: int = typer.Argument(..., help=""),
    b: int = typer.Argument(..., help=""),
) -> None:
    """Add two numbers."""
    result = _add_impl(a, b)
    if result is not None:
        typer.echo(result)
```

```
$ python ejected.py add 2 3
5
$ python ejected.py fetch example.com     # async tool
fetched example.com (3 retries)
```

I first tried a nested closure — smaller diff, no duplicated signature — but it breaks on any body that rebinds a parameter. `a = a * 2` makes `a` local to the closure and raises `UnboundLocalError`. Passing arguments explicitly avoids that, and the split leaves a clean reusable function in the ejected file.

## Also here

**Blank-line normalisation in `_render.py`.** The two template branches don't carry the same trailing whitespace, so getting one right broke the other. The API template was already emitting three consecutive blank lines today. Capping at PEP 8's two in the renderer fixes all three generators and keeps whitespace-control tags out of the templates.

## Tests

`test_async_tool_compiles` asserted `async def async_tool` for *every* generator — it encoded the broken CLI behaviour. Split: MCP and API still assert the async marker (both await handlers), CLI asserts the impl/`asyncio.run` shape.

Four new tests **execute** the generated module and invoke it through `CliRunner`, including one where the body echoes and returns `None`, to confirm no bare `None` gets printed. All three of the behavioural ones fail against the old template — verified.

Local: 155 passed, ruff clean, pyright 0 errors.

## Note on scope

While testing I found the same class of bug on the **conversion** path — `intpot to api examples/cli_app.py` also emits `-> dict` over a body returning `int`. That means #52's claim that the return-type bug was confined to eject is wrong, and it looks like the cause of #7. I'm correcting #52's description; this PR doesn't touch it.
