### PR TITLE
fix: serve --api now reads parameters from the sources it ejects

### DIFF
--- a/changelog.d/54.changed.md
+++ b/changelog.d/54.changed.md
@@ -1,0 +1,5 @@
+`intpot serve --api` now reads tool arguments from the request body instead of the
+query string, matching the code that `intpot eject --to api` generates. Serving and
+ejecting the same app previously produced two different HTTP interfaces. Parameters
+carrying an explicit source — `Query`, `Header`, or `Path` — are honoured as declared.
+**If you call a served app with query-string arguments, send a JSON body instead.**

--- a/src/intpot/runtime_builders.py
+++ b/src/intpot/runtime_builders.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from intpot.core.models import ParamSource, ToolInfo
 
 if TYPE_CHECKING:
     import typer as _typer
 
     from intpot.runtime import RegisteredTool
+
+_HTTP_METHODS = frozenset(
+    {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE"}
+)
 
 
 def build_typer_app(name: str, tools: list[RegisteredTool]) -> _typer.Typer:
@@ -36,6 +43,74 @@ def build_typer_app(name: str, tools: list[RegisteredTool]) -> _typer.Typer:
     return cli_app
 
 
+def _fastapi_endpoint(func: Callable[..., Any], info: ToolInfo) -> Callable[..., Any]:
+    """Wrap a tool so FastAPI reads its parameters from the declared sources.
+
+    Registering a plain function makes FastAPI infer a location per parameter,
+    and scalars become query parameters. Generated code declares the same
+    parameters via ``Body``/``Query``/``Header``/``Path`` from
+    ``ParameterInfo.param_source``, so serving and ejecting would otherwise
+    expose two different HTTP interfaces for one app.
+    """
+    import functools
+    import inspect
+    from typing import get_type_hints
+
+    from fastapi import Body, Header, Path, Query
+
+    markers = {
+        ParamSource.body: Body,
+        ParamSource.query: Query,
+        ParamSource.header: Header,
+        ParamSource.path: Path,
+    }
+    sources = {p.name: p.param_source for p in info.parameters}
+
+    try:
+        hints = get_type_hints(func)
+    except Exception:
+        hints = {}
+
+    signature = inspect.signature(func)
+    parameters = []
+    for param_name, param in signature.parameters.items():
+        marker = markers[sources.get(param_name) or ParamSource.body]
+        declared = (
+            marker(...)
+            if param.default is inspect.Parameter.empty
+            else marker(param.default)
+        )
+        parameters.append(
+            param.replace(
+                default=declared,
+                kind=inspect.Parameter.KEYWORD_ONLY,
+                annotation=hints.get(param_name, param.annotation),
+            )
+        )
+
+    endpoint: Callable[..., Any]
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def _async_endpoint(**kwargs: Any) -> Any:
+            return await func(**kwargs)
+
+        endpoint = _async_endpoint
+    else:
+
+        @functools.wraps(func)
+        def _sync_endpoint(**kwargs: Any) -> Any:
+            return func(**kwargs)
+
+        endpoint = _sync_endpoint
+
+    endpoint.__signature__ = signature.replace(  # type: ignore[attr-defined]
+        parameters=parameters,
+        return_annotation=hints.get("return", signature.return_annotation),
+    )
+    return endpoint
+
+
 def build_fastapi_app(name: str, tools: list[RegisteredTool]) -> object:
     """Construct a FastAPI app from registered tools."""
     try:
@@ -48,10 +123,16 @@ def build_fastapi_app(name: str, tools: list[RegisteredTool]) -> object:
 
     api_app = FastAPI(title=name)
     for tool in tools:
-        route_path = f"/{tool.info.name}"
-        method = tool.info.http_method.lower() if tool.info.http_method else "post"
-        handler = getattr(api_app, method, api_app.post)
-        handler(route_path, summary=tool.info.description)(tool.func)
+        route_path = tool.info.route_path or f"/{tool.info.name}"
+        method = (tool.info.http_method or "POST").upper()
+        if method not in _HTTP_METHODS:
+            method = "POST"
+        api_app.add_api_route(
+            route_path,
+            _fastapi_endpoint(tool.func, tool.info),
+            methods=[method],
+            summary=tool.info.description,
+        )
     return api_app
 
 

--- a/tests/test_runtime_builders.py
+++ b/tests/test_runtime_builders.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from typer.testing import CliRunner
 
 from intpot.runtime import App, RegisteredTool
@@ -59,6 +61,141 @@ def test_build_fastmcp_app():
 
     # FastMCP stores tools internally — check the name
     assert mcp_app.name == "test"
+
+
+def _openapi_operation(api_app, path: str, method: str = "post") -> dict:
+    return api_app.openapi()["paths"][path][method]
+
+
+def test_fastapi_params_come_from_the_body_not_the_query_string():
+    """Generated code declares Body(...), so the live server must agree.
+
+    Registering the plain function let FastAPI infer a location per parameter,
+    and scalars became query parameters — so `serve --api` and `eject --to api`
+    exposed two different HTTP interfaces for the same app.
+    """
+    from intpot.runtime_builders import build_fastapi_app
+
+    _, tools = _make_tools()
+    api_app = build_fastapi_app("test", tools)
+
+    operation = _openapi_operation(api_app, "/add")
+
+    assert "requestBody" in operation
+    assert operation.get("parameters", []) == []
+
+
+def test_fastapi_endpoint_serves_a_real_request():
+    from fastapi.testclient import TestClient
+
+    from intpot.runtime_builders import build_fastapi_app
+
+    _, tools = _make_tools()
+    api_app: Any = build_fastapi_app("test", tools)
+    client = TestClient(api_app)
+
+    response = client.post("/add", json={"a": 2, "b": 3})
+
+    assert response.status_code == 200
+    assert response.json() == 5
+
+
+def test_fastapi_endpoint_awaits_async_tools():
+    from fastapi.testclient import TestClient
+
+    from intpot.runtime_builders import build_fastapi_app
+
+    app = App("async-app")
+
+    @app.tool()
+    async def greet(name: str) -> str:
+        return f"Hello, {name}!"
+
+    api_app: Any = build_fastapi_app("test", app._tools)
+    client = TestClient(api_app)
+
+    # A lone Body() parameter is not embedded by FastAPI, so the body is the
+    # value itself — the generated code behaves the same way.
+    response = client.post("/greet", json="World")
+
+    assert response.status_code == 200
+    assert response.json() == "Hello, World!"
+
+
+def test_serving_and_ejecting_expose_the_same_interface():
+    """The invariant behind this whole builder: one app, one HTTP surface.
+
+    `serve --api` and `eject --to api` must not disagree about where a
+    parameter comes from.
+    """
+    from intpot.core.generators.api import APIGenerator
+    from intpot.runtime_builders import build_fastapi_app
+
+    app, tools = _make_tools()
+
+    live = build_fastapi_app("test", tools)
+    namespace: dict[str, Any] = {}
+    exec(compile(APIGenerator().generate(app.tools), "<generated>", "exec"), namespace)
+    generated = namespace["app"]
+
+    def interface(api_app) -> list[tuple]:
+        paths = api_app.openapi()["paths"]
+        return sorted(
+            (
+                path,
+                method,
+                tuple(sorted((p["name"], p["in"]) for p in op.get("parameters", []))),
+                "requestBody" in op,
+            )
+            for path, methods in paths.items()
+            for method, op in methods.items()
+        )
+
+    assert interface(live) == interface(generated)
+
+
+def test_fastapi_honours_a_declared_param_source():
+    """A tool carrying param_source=query keeps its query parameter."""
+    from intpot.core.models import ParameterInfo, ParamSource, ToolInfo
+    from intpot.runtime_builders import build_fastapi_app
+
+    def search(term: str) -> str:
+        return f"searching {term}"
+
+    tool = RegisteredTool(
+        func=search,
+        info=ToolInfo(
+            name="search",
+            parameters=[
+                ParameterInfo(
+                    name="term",
+                    type_annotation="str",
+                    param_source=ParamSource.query,
+                )
+            ],
+        ),
+    )
+
+    operation = _openapi_operation(build_fastapi_app("test", [tool]), "/search")
+
+    assert [(p["name"], p["in"]) for p in operation["parameters"]] == [
+        ("term", "query")
+    ]
+    assert "requestBody" not in operation
+
+
+def test_fastapi_falls_back_to_post_for_an_unknown_method():
+    from intpot.core.models import ToolInfo
+    from intpot.runtime_builders import build_fastapi_app
+
+    def ping() -> str:
+        return "pong"
+
+    tool = RegisteredTool(func=ping, info=ToolInfo(name="ping", http_method="openapi"))
+
+    api_app = build_fastapi_app("test", [tool])
+
+    assert list(api_app.openapi()["paths"]["/ping"]) == ["post"]
 
 
 def test_build_typer_app_runs_async_tool():


### PR DESCRIPTION
> ⚠️ **Behaviour change.** Callers of `intpot serve --api` that passed arguments in the query string must now send a JSON body. See *Compatibility* below.

## The bug

One app, two different HTTP interfaces:

```
serve  --api   ->  POST /add?a=2&b=3          # query parameters
eject --to api ->  POST /add  {"a":2,"b":3}   # request body
```

`build_fastapi_app` registered each tool function directly, so FastAPI inferred a location per parameter and scalars became query parameters. The generated code declares the same parameters as `Body(...)`. So **ejecting was not a faithful export of what the server had been serving** — which undercuts both halves of "write once, serve everywhere, then eject".

Confirmed against the live OpenAPI schema before the fix:

```
params: [('a', 'query'), ('b', 'query')] | requestBody: no
```

## The fix

The endpoint is wrapped with a signature whose defaults are the FastAPI markers named by `ParameterInfo.param_source` — `Body`, `Query`, `Header`, `Path` — defaulting to `Body`, which is what the templates already emit. The declared source now drives both paths from one place.

Two details worth calling out:

- Annotations are resolved through `get_type_hints` before building the new signature. `functools.wraps` rebinds `__globals__`, so a string annotation (any module using `from __future__ import annotations`) would otherwise be resolved against the wrong module and fail.
- Async tools get an async wrapper so FastAPI still awaits them. Previously the raw coroutine function was registered, which happened to work.

**Also:** route dispatch moved from `getattr(api_app, method, api_app.post)` to `add_api_route` with a validated method. The old lookup would resolve *any* attribute name — a tool whose `http_method` was `"openapi"` would have called FastAPI's `openapi()` as though it were a route decorator. This was in the review notes and is in the same function.

## Tests

The one that matters compares the OpenAPI parameter locations of the live app against an app produced by `exec`-ing the generated code, and asserts they're identical. That's the actual invariant — a hand-written expectation would drift as soon as either side changed.

Plus: body-not-query on the live app, a real request returning `5`, an awaited async tool, a `param_source=query` tool keeping its query parameter, and the unknown-method fallback. Five of six fail against the old builder — verified.

156 passed, ruff clean, pyright 0 errors.

## Compatibility

`serve --api` moves from query parameters to a JSON body. This is a breaking change for anyone scripting against a served app, which is why it's flagged at the top and filed under Changed rather than Fixed.

The alternative — making eject emit `Query(...)` to match the old runtime — would have contradicted #47, which deliberately made parameter sources explicit and preserved, with body as the declared default.

## Follow-up, not fixed here

A lone `Body()` parameter is not embedded by FastAPI, so a single-parameter tool takes a raw JSON value (`"World"`) while a two-parameter tool takes an object (`{"a":1,"b":2}`). Both paths now agree on this, so it's consistent — but the 1-vs-2 asymmetry is its own wart. Adding `embed=True` would fix it and would have to land in the runtime and the template together.
