### PR TITLE
docs: align positioning across surfaces and document 0.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Define your tools once with `@app.tool()` and serve them as any framework — or
 - **Directory auto-discovery** — scan an entire directory and convert all found apps at once
 - **Auto-detection** — automatically identifies the source framework by analyzing imports and patterns
 - **HTTP method preservation** — API routes keep their GET/POST/PUT/DELETE methods through conversion
+- **Parameter source preservation** — FastAPI `Query`, `Header`, `Path`, and `Body` parameters stay where they were, instead of collapsing into a request body
 - **Project scaffolding** — `intpot init` creates new CLI, MCP, or API projects from templates
 - **Jinja2 templates** — clean, readable generated code with proper type hints
 - **Fully typed** — PEP 561 compatible with `py.typed` marker
@@ -37,11 +38,14 @@ Define your tools once with `@app.tool()` and serve them as any framework — or
 ## Installation
 
 ```bash
-pip install intpot            # core (CLI conversions only)
+pip install intpot            # core: init, inspect, add skills, and Typer CLI output
 pip install intpot[mcp]       # + FastMCP support
 pip install intpot[api]       # + FastAPI support
 pip install intpot[all]       # everything
 ```
+
+The extras are only needed for frameworks you actually touch: reading a FastMCP server
+or emitting one requires `[mcp]`, and the same goes for `[api]` and FastAPI.
 
 ## Quick Start
 
@@ -63,6 +67,17 @@ def add(a: int, b: int) -> int:
 def greet(name: str, greeting: str = "Hello") -> str:
     """Greet someone by name."""
     return f"{greeting}, {name}!"
+```
+
+The tool name and description default to the function name and its docstring. Override
+either when the two audiences want different things — the docstring explains the code to
+whoever maintains it, the description tells an agent when to call the tool:
+
+```python
+@app.tool(name="lookup", description="Look up a customer by their account number.")
+def fetch_customer_record(account_id: str) -> dict:
+    """Hit the accounts table. Assumes the caller already validated account_id."""
+    ...
 ```
 
 Then serve in any mode:
@@ -183,7 +198,7 @@ app.write("output/api_app.py", "api")
 ```
 
 **`App`** (universal runtime):
-- `.tool()` — decorator to register functions as tools
+- `.tool(name=None, description=None)` — decorator to register functions as tools; both arguments override the defaults taken from the function name and docstring
 - `.serve(mode, host, port)` — serve as CLI, API, or MCP
 - `.eject(target)` — generate standalone framework code
 - `.tools` — list of normalized `ToolInfo` objects
@@ -196,7 +211,28 @@ app.write("output/api_app.py", "api")
 
 ## Architecture
 
-intpot uses a three-stage pipeline:
+Both halves of intpot meet at one normalized schema, `ToolInfo`. Everything upstream
+produces it; everything downstream consumes it.
+
+```
+   @app.tool()                        source .py file
+   (intpot.App)                    (Typer / FastMCP / FastAPI)
+        |                                    |
+        |                              1. DETECT
+        |                              2. INSPECT
+        |                                    |
+        +--------------> ToolInfo[] <--------+
+                              |
+              +---------------+---------------+
+              |                               |
+        build a live                    3. GENERATE
+      framework instance            (render a template)
+              |                               |
+       serve --cli/--api/--mcp        .py output on disk
+                                    (to cli/mcp/api, eject)
+```
+
+The conversion side is a three-stage pipeline:
 
 ```
                     +-----------+
@@ -233,6 +269,14 @@ intpot uses a three-stage pipeline:
 1. **DETECT** — `core/detector.py` imports the source file and identifies whether it's a Typer app, FastMCP server, or FastAPI app
 2. **INSPECT** — Framework-specific inspectors (`core/inspectors/`) extract function signatures, parameters, types, defaults, and docstrings into a normalized `ToolInfo` schema
 3. **GENERATE** — Framework-specific generators (`core/generators/`) render the normalized schema into target code using Jinja2 templates
+
+The runtime side skips detection and inspection: `@app.tool()` builds `ToolInfo`
+directly from the function signature, then either constructs a live framework instance
+(`serve`) or hands the same schema to the same generators (`eject`).
+
+> **Detection imports your source file.** `intpot to ...` and `intpot inspect` execute
+> the module to find the app instance, so any module-level code in it runs. Point them
+> at code you trust.
 
 ## Examples
 

--- a/changelog.d/55.changed.md
+++ b/changelog.d/55.changed.md
@@ -1,0 +1,3 @@
+The package description now reflects what intpot does — define tools once and serve them
+as a CLI, API, or MCP server, as well as converting between the three. The old text
+described only the converter, which predates the `intpot.App` runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "intpot"
 version = "0.4.2"
-description = "Universal converter between CLI (Typer), MCP (FastMCP), and API (FastAPI) interfaces"
+description = "Define Python tools once and serve them as a Typer CLI, FastAPI app, or FastMCP server — or convert existing apps between all three"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"

--- a/src/intpot/cli.py
+++ b/src/intpot/cli.py
@@ -22,7 +22,10 @@ def _version_callback(value: bool) -> None:
 
 app = typer.Typer(
     name="intpot",
-    help="Universal converter between CLI (Typer), MCP (FastMCP), and API (FastAPI) interfaces.",
+    help=(
+        "Define Python tools once and serve them as a Typer CLI, FastAPI app, "
+        "or FastMCP server — or convert existing apps between all three."
+    ),
     no_args_is_help=True,
 )
 
@@ -38,7 +41,7 @@ def main(
         help="Show version and exit.",
     ),
 ) -> None:
-    """Universal converter between CLI, MCP, and API interfaces."""
+    """Serve Python tools as a CLI, API, or MCP server — or convert between them."""
 
 
 to_app = typer.Typer(


### PR DESCRIPTION
## Positioning had drifted

The same sentence lived in three hand-maintained places, and all three still described intpot as *only* a converter:

- the GitHub repo description
- `pyproject.toml` (what PyPI renders)
- `cli.py` (what `intpot --help` prints)

Meanwhile the README has led with **"Write once, serve as CLI, API, or MCP"** since 0.4.0. So the first thing anyone saw — on GitHub, on PyPI, or in their terminal — omitted the headline feature.

All three now read:

> Define Python tools once and serve them as a Typer CLI, FastAPI app, or FastMCP server — or convert existing apps between all three.

The old text also claimed conversion of "any Python app", which overpromises: it's Typer, FastMCP, and FastAPI specifically.

The repo description is updated already (it isn't in version control). The `pyproject.toml` change reaches PyPI on the next release.

## 0.4.2 was undocumented

Both features shipped yesterday and appeared nowhere in the README:

- `@app.tool(name=..., description=...)` — the API reference still listed `.tool()` as taking no arguments. Added with an example of when the override earns its keep: the docstring explains the code to a maintainer, the description tells an agent when to call the tool.
- Parameter source preservation — added to Features.

## Architecture section

It described only DETECT → INSPECT → GENERATE, so the runtime path — the headline feature — was missing from the one section explaining how the thing works. Added a diagram showing both paths converging on `ToolInfo`, which is the actual shape of the codebase:

```
   @app.tool()                        source .py file
        |                              1. DETECT / 2. INSPECT
        +--------------> ToolInfo[] <--------+
              +---------------+---------------+
        build a live                    3. GENERATE
      framework instance            (render a template)
```

## Two smaller corrections

- **Detection executes your source file.** `detector.py` calls `exec_module` to find the app instance, so module-level code runs. Worth a warning before someone points `intpot to cli` at unfamiliar code.
- The install matrix called core "CLI conversions only". It also covers `init`, `inspect`, and `add skills`.

Docs only — no behaviour change. 150 passed, ruff clean, pyright 0 errors, and `intpot --help` verified.
