### PR TITLE
fix: wrap scalar returns when converting to FastAPI

### DIFF
--- a/changelog.d/56.fixed.md
+++ b/changelog.d/56.fixed.md
@@ -1,0 +1,5 @@
+`intpot to api` no longer generates handlers that fail on every request. Converted
+handlers are annotated `-> dict`, but the body returned whatever the source function
+returned, so FastAPI rejected the response. Scalar returns are now wrapped as
+`{"result": ...}` — matching the stub the converter already emits for tools with no
+body — while sources that already return a mapping are left as they are.

--- a/src/intpot/core/transforms.py
+++ b/src/intpot/core/transforms.py
@@ -26,10 +26,23 @@ def transform_tools(
 
         if t.function_body:
             t.function_body = _transform_body(t.function_body, source, target)
+            if (
+                target == SourceType.API
+                and source != target
+                and not _is_dict_type(tool.return_type)
+            ):
+                t.function_body = _wrap_returns_in_dict(t.function_body)
 
-        t.return_type = _target_return_type(tool, source, target)
+        # Pass the transformed tool: a CLI body's typer.echo() has become a
+        # return by this point, and the annotation has to describe that.
+        t.return_type = _target_return_type(t, source, target)
         result.append(t)
     return result
+
+
+def _is_dict_type(return_type: str) -> bool:
+    """Whether an annotation already denotes a mapping FastAPI can serve as-is."""
+    return return_type.lstrip("\"'").lower().startswith("dict")
 
 
 def _target_return_type(tool: ToolInfo, source: SourceType, target: SourceType) -> str:
@@ -37,6 +50,11 @@ def _target_return_type(tool: ToolInfo, source: SourceType, target: SourceType) 
     if target == SourceType.CLI:
         return "None"
     if target == SourceType.API:
+        # FastAPI validates the response against this annotation, so it has to
+        # describe what the body actually returns. Every explicit return is
+        # wrapped into a dict above; a body with no return falls through to None.
+        if tool.function_body and not _has_top_level_return(tool.function_body):
+            return "None"
         return "dict"
     # MCP: preserve original if coming from MCP/API, use str from CLI
     if source == SourceType.CLI:
@@ -200,6 +218,76 @@ def _returns_to_echo(body: str) -> str:
     new_tree = transformer.visit(tree)
     ast.fix_missing_locations(new_tree)
     return ast.unparse(new_tree)
+
+
+class _TopLevelReturnVisitor(ast.NodeVisitor):
+    """Track whether a body returns at its own scope, ignoring nested defs."""
+
+    def __init__(self) -> None:
+        self.found = False
+        self._depth = 0
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._depth += 1
+        self.generic_visit(node)
+        self._depth -= 1
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_Return(self, node: ast.Return) -> None:
+        if self._depth == 0:
+            self.found = True
+
+
+def _has_top_level_return(body: str) -> bool:
+    try:
+        tree = ast.parse(body)
+    except SyntaxError:
+        return False
+    visitor = _TopLevelReturnVisitor()
+    visitor.visit(tree)
+    return visitor.found
+
+
+def _wrap_returns_in_dict(body: str) -> str:
+    """Wrap `return X` as `return {'result': X}` for FastAPI targets.
+
+    A converted handler is annotated `-> dict`, and FastAPI validates the
+    response against that annotation. Returning the source function's raw
+    scalar produced a ResponseValidationError on every call.
+    """
+    try:
+        tree = ast.parse(body)
+    except SyntaxError:
+        return body
+
+    new_tree = _WrapReturnInDict().visit(tree)
+    ast.fix_missing_locations(new_tree)
+    return ast.unparse(new_tree)
+
+
+class _WrapReturnInDict(ast.NodeTransformer):
+    """Replace `return X` with `return {'result': X}` at the body's own scope."""
+
+    def __init__(self) -> None:
+        self._depth = 0
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
+        self._depth += 1
+        result = self.generic_visit(node)
+        self._depth -= 1
+        return result
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_Return(self, node: ast.Return) -> ast.AST:
+        if self._depth > 0 or node.value is None:
+            return node
+        if isinstance(node.value, ast.Dict):
+            return node  # already a mapping — don't nest it
+        return ast.Return(
+            value=ast.Dict(keys=[ast.Constant(value="result")], values=[node.value])
+        )
 
 
 class _ReturnToEcho(ast.NodeTransformer):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,105 @@
+"""Tests for framework-to-framework body and return-type transformation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from intpot.core.generators.api import APIGenerator
+from intpot.core.models import _SENTINEL, ParameterInfo, SourceType, ToolInfo
+from intpot.core.transforms import transform_tools
+
+
+def _add_tool(body: str, return_type: str = "str") -> ToolInfo:
+    return ToolInfo(
+        name="add",
+        description="Add two numbers.",
+        parameters=[
+            ParameterInfo(name="a", type_annotation="int", default=_SENTINEL),
+            ParameterInfo(name="b", type_annotation="int", default=_SENTINEL),
+        ],
+        return_type=return_type,
+        function_body=body,
+    )
+
+
+def _to_api(tool: ToolInfo, source: SourceType) -> ToolInfo:
+    return transform_tools([tool], source, SourceType.API)[0]
+
+
+def test_cli_to_api_wraps_a_scalar_return():
+    """`-> dict` is only honest if the body actually returns a mapping.
+
+    typer.echo(a + b) becomes `return a + b`, which FastAPI then rejected
+    against the dict annotation with a ResponseValidationError.
+    """
+    result = _to_api(_add_tool("typer.echo(a + b)"), SourceType.CLI)
+
+    assert result.function_body == "return {'result': a + b}"
+    assert result.return_type == "dict"
+
+
+def test_mcp_to_api_wraps_a_scalar_return():
+    result = _to_api(_add_tool("return a + b"), SourceType.MCP)
+
+    assert result.function_body == "return {'result': a + b}"
+    assert result.return_type == "dict"
+
+
+def test_a_dict_return_is_not_nested_again():
+    """A source already returning a mapping needs no wrapping."""
+    tool = _add_tool("return {'sum': a + b}", return_type="dict")
+
+    result = _to_api(tool, SourceType.MCP)
+
+    assert result.function_body == "return {'sum': a + b}"
+    assert result.return_type == "dict"
+
+
+def test_a_body_that_never_returns_is_annotated_none():
+    """Falling off the end yields None, which `-> dict` would also reject."""
+    tool = ToolInfo(name="ping", description="Ping.", function_body="print('pong')")
+
+    result = _to_api(tool, SourceType.CLI)
+
+    assert result.return_type == "None"
+
+
+def test_returns_inside_a_nested_function_are_left_alone():
+    body = "def helper():\n    return a + b\nreturn helper()"
+
+    result = _to_api(_add_tool(body), SourceType.MCP)
+
+    body = result.function_body or ""
+    assert "return a + b" in body
+    assert "return {'result': helper()}" in body
+
+
+def test_converted_api_app_serves_a_real_request():
+    """The end-to-end check: convert, execute the output, call it."""
+    tool = _to_api(_add_tool("typer.echo(a + b)"), SourceType.CLI)
+    namespace: dict[str, Any] = {}
+    exec(compile(APIGenerator().generate([tool]), "<generated>", "exec"), namespace)
+
+    response = TestClient(namespace["app"]).post("/add", json={"a": 2, "b": 3})
+
+    assert response.status_code == 200
+    assert response.json() == {"result": 5}
+
+
+def test_api_target_does_not_change_other_targets():
+    """Wrapping is FastAPI-specific; CLI and MCP output is untouched."""
+    cli = transform_tools([_add_tool("return a + b")], SourceType.MCP, SourceType.CLI)[
+        0
+    ]
+    mcp = transform_tools(
+        [_add_tool("return a + b", return_type="int")],
+        SourceType.API,
+        SourceType.MCP,
+    )[0]
+
+    assert "result" not in (cli.function_body or "")
+    assert cli.return_type == "None"
+    assert mcp.function_body == "return a + b"
+    assert mcp.return_type == "int"


### PR DESCRIPTION
Closes #7.

## The bug

`intpot to api` still produces handlers that 500 on every call — after #52.

```
$ intpot to api cli_app.py     # then POST /add {"a": 2, "b": 3}
500   ResponseValidationError: Input should be a valid dictionary, input: 5
```

#52 made the template honour `tool.return_type` instead of hardcoding `-> dict`. But `transforms.py` sets that type to `"dict"` unconditionally for any API target, while `_transform_body` rewrites `typer.echo(a + b)` into `return a + b`:

```python
@app.post("/add")
def add(a: int = Body(...), b: int = Body(...)) -> dict:
    return a + b        # <- annotation says dict, body says int
```

So the template was already faithful. The lie was one layer up, in `_target_return_type`.

**#52 did not close #7, though its description claimed it would.** It only fixed the eject path, where `return_type` comes from the real function signature rather than being overwritten here. I've corrected that claim on #52.

## The fix

Explicit returns are wrapped as `return {"result": X}` — matching the shape the stub path already emits (`return {"result": "add called"}`) and what #7 asked for.

```python
def add(a: int = Body(...), b: int = Body(...)) -> dict:
    return {'result': a + b}
```

```
POST /add {"a":2,"b":3}  ->  200  {"result":5}
```

Three cases handled around it:

- **A body already returning a mapping is left alone** rather than nested into `{"result": {...}}`. Decided from the source tool's declared return type plus an AST check for a dict literal.
- **A body that never returns is annotated `-> None`**, not `-> dict`. Falling off the end yields `None`, which FastAPI would reject against `dict` just as readily.
- **Returns inside nested functions are untouched** — only the body's own scope is rewritten.

Only the FastAPI target is affected. CLI and MCP conversions are unchanged, and there's a test asserting that.

## Tests

New `tests/test_transforms.py` — the file didn't exist, despite `transforms.py` being 236 lines behind every conversion. Seven tests: scalar wrapping from both CLI and MCP sources, dict passthrough, the no-return case, nested-function isolation, non-API targets unaffected, and an end-to-end one that converts, `exec`s the output, and issues a real request.

Five fail against the old transform — verified.

171 passed, ruff clean, pyright 0 errors.

## Known gap

A body that returns on some paths and falls through on others gets `-> dict` and would still fail on the fall-through. Detecting that needs control-flow analysis, which felt disproportionate here.
