### PR TITLE
fix: serve --cli now passes arguments to the served app

### DIFF
--- a/changelog.d/58.fixed.md
+++ b/changelog.d/58.fixed.md
@@ -1,0 +1,4 @@
+`intpot serve --cli` can now actually run your tools. Arguments meant for the served app
+were rejected by intpot's own argument parser, and any that got past it were discarded
+before Typer saw them, so the command could only ever print an error. Use `--` to pass
+through a flag that intpot also defines, such as `--port`.

--- a/src/intpot/cli.py
+++ b/src/intpot/cli.py
@@ -58,7 +58,11 @@ add_app = typer.Typer(
 
 app.command("init")(init_command)
 app.command("inspect")(inspect_command)
-app.command("serve")(serve_command)
+app.command(
+    "serve",
+    # Arguments intpot does not recognise belong to the served app, not to us.
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)(serve_command)
 app.command("eject")(eject_command)
 to_app.command("cli")(to_cli)
 to_app.command("mcp")(to_mcp)

--- a/src/intpot/commands/serve.py
+++ b/src/intpot/commands/serve.py
@@ -27,6 +27,7 @@ def _find_intpot_app(source_path: Path) -> object:
 
 
 def serve_command(
+    ctx: typer.Context,
     source: Path = typer.Argument(
         ..., help="Path to a Python file containing an intpot App"
     ),
@@ -52,10 +53,17 @@ def serve_command(
     app_instance = _find_intpot_app(source_path)
     assert isinstance(app_instance, App)
 
-    # For CLI mode, pass remaining args through
     mode = selected[0]
-    if mode == "cli":
-        # Strip our own args so Typer gets the user's CLI args
-        sys.argv = [str(source_path)]
+    if mode != "cli":
+        app_instance.serve(mode=mode, host=host, port=port)
+        return
 
-    app_instance.serve(mode=mode, host=host, port=port)
+    # The served Typer app reads sys.argv, so hand it the user's arguments in
+    # place of our own. Anything intpot did not consume arrives in ctx.args;
+    # use `--` to pass through a flag that intpot also defines.
+    original_argv = sys.argv
+    sys.argv = [str(source_path), *ctx.args]
+    try:
+        app_instance.serve(mode=mode, host=host, port=port)
+    finally:
+        sys.argv = original_argv

--- a/tests/test_commands/test_serve.py
+++ b/tests/test_commands/test_serve.py
@@ -48,3 +48,65 @@ def test_serve_no_app_found(tmp_source):
     result = runner.invoke(app, ["serve", str(source), "--cli"])
     assert result.exit_code == 1
     assert "No intpot App" in result.output
+
+
+def _two_tool_app(tmp_source):
+    return tmp_source("""
+        from intpot import App
+        app = App("demo")
+
+        @app.tool()
+        def add(a: int, b: int) -> int:
+            \"\"\"Add two numbers.\"\"\"
+            return a + b
+
+        @app.tool()
+        def greet(name: str, greeting: str = "Hello") -> str:
+            \"\"\"Greet someone.\"\"\"
+            return f"{greeting}, {name}!"
+    """)
+
+
+def test_serve_cli_runs_the_named_tool(tmp_source):
+    """`serve --cli` was unusable: intpot's own parser rejected the tool's
+    arguments, and the ones that got through were discarded before Typer saw
+    them."""
+    source = _two_tool_app(tmp_source)
+
+    result = runner.invoke(app, ["serve", str(source), "--cli", "add", "2", "3"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "5"
+
+
+def test_serve_cli_forwards_options_it_does_not_own(tmp_source):
+    source = _two_tool_app(tmp_source)
+
+    result = runner.invoke(
+        app, ["serve", str(source), "--cli", "greet", "World", "--greeting", "Hi"]
+    )
+
+    assert result.exit_code == 0
+    assert "Hi, World!" in result.output
+
+
+def test_serve_cli_accepts_a_double_dash_separator(tmp_source):
+    """`--` is the escape hatch for a flag intpot also defines."""
+    source = _two_tool_app(tmp_source)
+
+    result = runner.invoke(app, ["serve", str(source), "--cli", "--", "greet", "World"])
+
+    assert result.exit_code == 0
+    assert "Hello, World!" in result.output
+
+
+def test_serve_restores_argv(tmp_source):
+    """serve rewrites sys.argv for the served app; it must put it back."""
+    import sys
+
+    source = _two_tool_app(tmp_source)
+    before = list(sys.argv)
+
+    runner.invoke(app, ["serve", str(source), "--cli", "add", "1", "1"])
+
+    assert sys.argv == before


### PR DESCRIPTION
## The bug

`intpot serve app.py --cli` — documented in the README as "Run as Typer CLI" — could not invoke a tool at all. Either way you tried it:

```
$ intpot serve app.py --cli add 2 3
Error: Got unexpected extra arguments (add 2 3)

$ intpot serve app.py --cli
Usage: app.py [OPTIONS] COMMAND [ARGS]...
Error: Missing command.
```

Two problems stacked:

1. `serve` was registered as a plain Typer command, so **intpot's own parser rejected the user's arguments** before the body ever ran.
2. The body then did `sys.argv = [str(source_path)]`, which **discarded them anyway** — directly beneath a comment reading `# For CLI mode, pass remaining args through`. The intent was written down; the code did the opposite.

Only the second is visible by reading `serve.py`. The first is in `cli.py`, which is why the runtime builder tested clean while the command was unusable.

## The fix

`serve` is registered with `allow_extra_args` and `ignore_unknown_options`, so anything intpot doesn't recognise lands in `ctx.args` and gets forwarded to the served app.

```
$ intpot serve app.py --cli add 2 3
5
$ intpot serve app.py --cli greet World --greeting Hi
Hi, World!
```

`--greeting` isn't an intpot option, so it passes straight through. For a flag intpot *does* define — `--port`, say — `--` is the escape hatch:

```
$ intpot serve app.py --cli -- greet World --greeting Hey
Hey, World!
```

`sys.argv` is now restored in a `finally`. The old code left the process argv rewritten; harmless only because serving is terminal.

## Tests

Four added: running a named tool, forwarding an unowned option, the `--` separator, and one asserting `sys.argv` is put back. Three fail against the old command — verified by stashing only the source changes, keeping the tests.

175 passed, ruff clean, pyright 0 errors.

## Note

I missed this in the first review. I read `runtime_builders.build_typer_app`, confirmed the builder was correct, and didn't run the command that reaches it — the same string-vs-execution gap behind the earlier generator bugs.
