### PR TITLE
fix: one unimportable file no longer aborts a directory scan

### DIFF
--- a/changelog.d/59.fixed.md
+++ b/changelog.d/59.fixed.md
@@ -1,0 +1,4 @@
+Converting a directory no longer aborts when one file fails to import. Discovery
+executes each candidate module to find its app instance, and any error other than a
+missing app propagated out and killed the whole scan, so none of the working files were
+converted either. Bad files are now skipped with a message on stderr.

--- a/src/intpot/core/discovery.py
+++ b/src/intpot/core/discovery.py
@@ -47,13 +47,20 @@ def discover_sources(
 
         try:
             source_type, app_instance = detect_source(py_file)
-        except SyntaxError:
-            if verbose:
-                print(f"SKIP (syntax): {py_file}", file=sys.stderr)
-            continue
-        except (DetectionError, ImportError, OSError):
+        except DetectionError:
+            # Ordinary: most files in a project are not framework apps.
             if verbose:
                 print(f"SKIP (no app): {py_file}", file=sys.stderr)
+            continue
+        except Exception as exc:
+            # Detection imports the module, so this is the file's own code
+            # failing. One unimportable file must not abort the whole scan,
+            # but it is worth reporting even without --verbose: the file
+            # looked like an app and still produced nothing.
+            print(
+                f"SKIP (import failed): {py_file}: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
             continue
 
         if verbose:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -89,3 +89,67 @@ def test_discover_skips_pycache(tmp_path: Path):
 
     results = discover_sources(tmp_path)
     assert results == []
+
+
+def test_one_unimportable_file_does_not_abort_the_scan(tmp_path: Path, capsys):
+    """Detection executes each candidate, so a module can raise anything.
+
+    Only DetectionError, ImportError and OSError were caught, and everything
+    else propagated out of the scan — one bad file took down the whole run and
+    the good ones were never converted.
+    """
+    _write(
+        tmp_path,
+        "boom.py",
+        """\
+        from fastmcp import FastMCP
+        mcp = FastMCP("boom")
+        raise ValueError("module-level failure")
+        """,
+    )
+    _write(
+        tmp_path,
+        "good.py",
+        """\
+        from fastmcp import FastMCP
+        mcp = FastMCP("good")
+
+        @mcp.tool()
+        def hello(name: str) -> str:
+            return name
+        """,
+    )
+
+    results = discover_sources(tmp_path)
+
+    assert [p.name for p, _, _ in results] == ["good.py"]
+    assert "SKIP (import failed)" in capsys.readouterr().err
+
+
+def test_an_import_failure_is_reported_without_verbose(tmp_path: Path, capsys):
+    """A file that looked like an app and yielded nothing is worth saying out loud."""
+    _write(
+        tmp_path,
+        "boom.py",
+        """\
+        from fastmcp import FastMCP
+        mcp = FastMCP("boom")
+        raise RuntimeError("nope")
+        """,
+    )
+
+    discover_sources(tmp_path, verbose=False)
+
+    err = capsys.readouterr().err
+    assert "boom.py" in err
+    assert "RuntimeError: nope" in err
+
+
+def test_files_without_an_app_stay_quiet(tmp_path: Path, capsys):
+    """The common case — most files are not apps — must not be noisy."""
+    _write(tmp_path, "plain.py", "x = 42\n")
+
+    results = discover_sources(tmp_path)
+
+    assert results == []
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
## The bug

`detect_source` **executes** each candidate module to find the app instance, so it can raise anything the file's own code raises. `discover_sources` caught only `(DetectionError, ImportError, OSError)`, so everything else propagated out and killed the run.

Reproduced with a directory holding one working FastAPI app and one that raises at import:

```
$ intpot to cli ./scan/
Traceback (most recent call last):
  File "/scan/boom.py", line 3, in <module>
    raise ValueError("module-level failure")
ValueError: module-level failure
```

Exit 1, nothing converted — `good.py` never got looked at.

## The fix

Unexpected exceptions are caught per file and reported as a skip:

```
$ intpot to cli ./scan/
SKIP (import failed): /scan/boom.py: ValueError: module-level failure
# good.py converted, exit 0
```

The report goes to **stderr unconditionally**, not just under `--verbose`. The file passed the AST check, so it looked like a framework app and still produced nothing — silently dropping it is how you end up believing a directory was fully converted when it wasn't. Files with no app at all stay quiet, since that's the normal case for most of a project.

Also drops the `except SyntaxError` branch above it. It couldn't fire: `_has_framework_app_ast` already swallows `SyntaxError` and turns it into `DetectionError` before any import happens.

## Tests

Three added: the mixed good/bad directory still yields the good file, an import failure is reported without `--verbose`, and a plain non-app file stays silent. The first two fail against the old handler — verified by stashing only `discovery.py`.

174 passed, ruff clean, pyright 0 errors.
