### PR TITLE
fix: bind loopback by default, survive unreadable metadata, keep leading underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ def greet(name: str, greeting: str = "Hello") -> str:
 
 # Serve as any framework
 app.serve(mode="cli")                         # Run as Typer CLI
-app.serve(mode="api", host="0.0.0.0", port=8000)  # Run as FastAPI
+app.serve(mode="api", port=8000)              # Run as FastAPI on 127.0.0.1
 app.serve(mode="mcp")                         # Run as MCP server
 
 # Eject to standalone code
@@ -419,7 +419,7 @@ intpot serve <source> --cli|--api|--mcp [--host <host>] [--port <port>]
 | `--cli` | Serve as a Typer CLI |
 | `--api` | Serve as a FastAPI app |
 | `--mcp` | Serve as a FastMCP server |
-| `--host` | API server host (default: `0.0.0.0`) |
+| `--host` | API server host (default: `127.0.0.1` — pass `0.0.0.0` to expose it on the network) |
 | `--port` | API server port (default: `8000`) |
 
 ### `intpot eject`

--- a/changelog.d/60.changed.md
+++ b/changelog.d/60.changed.md
@@ -1,0 +1,6 @@
+`intpot serve --api` and `App.serve(mode="api")` now bind `127.0.0.1` instead of
+`0.0.0.0`, so a served app is no longer reachable from the network by default. **Pass
+`--host 0.0.0.0` if you were relying on that.** Alongside it, `intpot --version` no
+longer crashes when package metadata is unreadable, and identifiers keep their leading
+underscores — `_name` used to be rewritten to `name`, which could collide with a real
+`name` in generated code.

--- a/src/intpot/__init__.py
+++ b/src/intpot/__init__.py
@@ -1,13 +1,17 @@
-"""intpot - Universal converter between CLI, MCP, and API interfaces."""
+"""intpot - serve Python tools as a CLI, API, or MCP server, or convert between them."""
 
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import version
 
 from intpot.converter import IntpotApp, inspect_app, load
 from intpot.runtime import App
 
 try:
     __version__ = version("intpot")
-except PackageNotFoundError:  # source tree that was never installed
+except Exception:
+    # Not installed, or the installed metadata is unreadable — an incomplete
+    # dist-info makes importlib raise TypeError rather than
+    # PackageNotFoundError. Reporting a version is never worth failing an
+    # import or a --version call over.
     __version__ = "0.0.0+unknown"
 
 __all__ = ["App", "IntpotApp", "inspect_app", "load"]

--- a/src/intpot/cli.py
+++ b/src/intpot/cli.py
@@ -14,9 +14,9 @@ from intpot.commands.to_mcp import to_mcp
 
 def _version_callback(value: bool) -> None:
     if value:
-        from importlib.metadata import version
+        from intpot import __version__
 
-        typer.echo(f"intpot {version('intpot')}")
+        typer.echo(f"intpot {__version__}")
         raise typer.Exit()
 
 

--- a/src/intpot/commands/serve.py
+++ b/src/intpot/commands/serve.py
@@ -34,7 +34,11 @@ def serve_command(
     cli: bool = typer.Option(False, "--cli", help="Serve as Typer CLI"),
     api: bool = typer.Option(False, "--api", help="Serve as FastAPI"),
     mcp: bool = typer.Option(False, "--mcp", help="Serve as FastMCP server"),
-    host: str = typer.Option("0.0.0.0", "--host", help="API server host"),
+    host: str = typer.Option(
+        "127.0.0.1",
+        "--host",
+        help="API server host (use 0.0.0.0 to expose it on the network)",
+    ),
     port: int = typer.Option(8000, "--port", help="API server port"),
 ) -> None:
     """Serve an intpot App as CLI, API, or MCP server."""

--- a/src/intpot/core/models.py
+++ b/src/intpot/core/models.py
@@ -53,16 +53,21 @@ def sanitize_identifier(name: str) -> str:
     """Convert an arbitrary string into a valid Python identifier.
 
     - Replaces invalid characters with ``_``
+    - Collapses runs of ``_`` into one
     - Prepends ``_`` if the name starts with a digit
     - Appends ``_`` if the name is a Python keyword
     - Returns ``_`` for empty / whitespace-only input
+
+    Leading and trailing underscores are preserved: stripping them collapsed
+    ``_name`` onto ``name``, so two distinct parameters could end up sharing an
+    identifier in the generated code.
     """
     if not name or not name.strip():
         return "_"
     # Replace any character that is not alphanumeric or underscore
     name = re.sub(r"[^0-9a-zA-Z_]", "_", name)
     # Collapse consecutive underscores
-    name = re.sub(r"_+", "_", name).strip("_")
+    name = re.sub(r"_+", "_", name)
     if not name:
         return "_"
     # Prepend underscore if starts with digit

--- a/src/intpot/runtime.py
+++ b/src/intpot/runtime.py
@@ -98,12 +98,13 @@ class App:
         generator_cls = getattr(mod, class_name)
         return generator_cls().generate(self.tools)
 
-    def serve(self, mode: str, *, host: str = "0.0.0.0", port: int = 8000) -> None:
+    def serve(self, mode: str, *, host: str = "127.0.0.1", port: int = 8000) -> None:
         """Serve the registered tools in the specified mode.
 
         Args:
             mode: One of "cli", "api", "mcp".
-            host: Host for API mode (default "0.0.0.0").
+            host: Host for API mode (default "127.0.0.1" — loopback only; pass
+                "0.0.0.0" to expose the server on the network).
             port: Port for API mode (default 8000).
         """
         if not self._tools:

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -253,3 +253,19 @@ class TestRoutePath:
         code = gen.generate([tool])
         compile(code, "<string>", "exec")
         assert "/get_users" in code
+
+
+class TestLeadingUnderscores:
+    def test_leading_underscore_is_preserved(self) -> None:
+        """Stripping it collapsed `_name` onto `name`, so two distinct
+        parameters could share one identifier in the generated code."""
+        assert sanitize_identifier("_name") == "_name"
+        assert sanitize_identifier("_name") != sanitize_identifier("name")
+
+    def test_dunder_survives_as_a_distinct_name(self) -> None:
+        assert sanitize_identifier("__init__") == "_init_"
+        assert sanitize_identifier("__init__").isidentifier()
+
+    def test_underscore_runs_still_collapse(self) -> None:
+        assert sanitize_identifier("user__id") == "user_id"
+        assert sanitize_identifier("---") == "_"

--- a/tests/test_commands/test_serve.py
+++ b/tests/test_commands/test_serve.py
@@ -110,3 +110,18 @@ def test_serve_restores_argv(tmp_source):
     runner.invoke(app, ["serve", str(source), "--cli", "add", "1", "1"])
 
     assert sys.argv == before
+
+
+def test_serve_binds_loopback_by_default():
+    """Serving should not expose the app on the network unless asked."""
+    import re
+
+    result = runner.invoke(app, ["serve", "--help"])
+    clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+
+    assert "0.0.0.0" not in clean.split("--host")[0]
+    import inspect as _inspect
+
+    from intpot.runtime import App
+
+    assert _inspect.signature(App.serve).parameters["host"].default == "127.0.0.1"


### PR DESCRIPTION
The three carried-over items from review. None is a crash in normal use, which is why they'd survived; grouped because they're all small hardening.

## 1. `0.0.0.0` by default

`App.serve()` and `intpot serve --api` bound every interface, so following the README's example put the app on the local network without asking. Default is now `127.0.0.1`, and `--host 0.0.0.0` opts into exposure. README updated.

## 2. `intpot --version` crashed on unreadable metadata

`cli.py` called `importlib.metadata.version('intpot')` bare. An incomplete `dist-info` makes that raise:

```
TypeError: 'NoneType' object is not subscriptable
```

— not `PackageNotFoundError`, which is the only thing `__init__.py` guarded. So the flag crashed instead of degrading. I hit this twice in my own venv while working on this repo.

`--version` now reads `intpot.__version__`, and that guard is widened to cover unreadable metadata as well as absent metadata. Reporting a version isn't worth failing an import over.

## 3. `sanitize_identifier` stripped leading underscores

`_name` → `name`, colliding with a real `name`; `__init__` → `init`. Two distinct parameters could end up sharing one identifier in generated code.

Only the strip is removed — runs still collapse, so behaviour holds everywhere else:

| input | before | after |
|-------|--------|-------|
| `_name` | `name` | `_name` |
| `__init__` | `init` | `_init_` |
| `user__id` | `user_id` | `user_id` |
| `---` | `_` | `_` |
| `class` | `class_` | `class_` |

The docstring documented neither the stripping nor the collapsing; both are written down now.

## Tests

Four added across `test_adversarial.py` and `test_serve.py`. Three fail against the old code — verified by stashing only the source files.

175 passed, ruff clean, pyright 0 errors.

## Deliberately not changed

The `0.0.0.0` in the generated `api_app.py.j2` template and the API scaffold. Those are the *user's* app rather than ours, and changing them regenerates every fixture in `examples/conversions/` — worth doing, but not silently inside a hardening PR. Say the word and it's a follow-up.
