### PR TITLE
fix: narrow two overreaching behaviours introduced in #53 and #54

### DIFF
--- a/changelog.d/61.fixed.md
+++ b/changelog.d/61.fixed.md
@@ -1,0 +1,5 @@
+Tools declaring `*args` or `**kwargs` no longer break `intpot serve --api` — variadic
+parameters have no HTTP equivalent and are left out of the route instead of producing a
+signature FastAPI cannot serve. Generated code also stops reformatting the blank lines
+inside a preserved function body; only the spacing between top-level definitions is
+normalised.

--- a/src/intpot/core/generators/_render.py
+++ b/src/intpot/core/generators/_render.py
@@ -91,11 +91,13 @@ def _collect_extra_imports(tools: list[ToolInfo]) -> list[str]:
     return sorted(result)
 
 
-_EXCESS_BLANK_LINES = re.compile(r"\n{4,}")
+# Only runs that precede a top-level line: those are the template seams. A run
+# inside a function body or a docstring belongs to the source and is left alone.
+_EXCESS_BLANK_LINES = re.compile(r"\n{4,}(?=\S)")
 
 
 def _normalize_blank_lines(code: str) -> str:
-    """Collapse runs of more than two consecutive blank lines.
+    """Collapse runs of more than two blank lines before a top-level statement.
 
     Templates branch on whether a tool has a preserved body, and the two
     branches do not carry the same trailing whitespace. Normalising here keeps

--- a/src/intpot/runtime_builders.py
+++ b/src/intpot/runtime_builders.py
@@ -71,9 +71,17 @@ def _fastapi_endpoint(func: Callable[..., Any], info: ToolInfo) -> Callable[...,
     except Exception:
         hints = {}
 
+    variadic = (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+
     signature = inspect.signature(func)
     parameters = []
     for param_name, param in signature.parameters.items():
+        if param.kind in variadic:
+            # *args / **kwargs cannot be expressed as HTTP parameters. Leaving
+            # them out means the wrapper simply never passes them, which is
+            # what an empty tuple and dict amount to anyway; rewriting them to
+            # KEYWORD_ONLY produced a signature FastAPI could not serve.
+            continue
         marker = markers[sources.get(param_name) or ParamSource.body]
         declared = (
             marker(...)

--- a/tests/test_generators/test_api_generator.py
+++ b/tests/test_generators/test_api_generator.py
@@ -85,3 +85,21 @@ def test_generated_app_serves_a_real_request():
 
     assert response.status_code == 200
     assert response.json() == 5
+
+
+def test_blank_lines_inside_a_body_are_preserved():
+    """Normalisation targets template seams, not the source's own spacing."""
+    body = "first = 1\n\n\n\nsecond = 2\nreturn {'a': first + second}"
+    tool = ToolInfo(name="spaced", description="Spaced.", function_body=body)
+
+    code = APIGenerator().generate([tool])
+
+    assert "first = 1\n\n\n\n    second = 2" in code
+
+
+def test_blank_lines_between_top_level_defs_are_capped():
+    tools = [_add_tool("return a + b"), _add_tool("return a + b")]
+
+    code = APIGenerator().generate(tools)
+
+    assert "\n\n\n\n" not in code

--- a/tests/test_runtime_builders.py
+++ b/tests/test_runtime_builders.py
@@ -213,3 +213,31 @@ def test_build_typer_app_runs_async_tool():
 
     assert result.exit_code == 0
     assert "Hello, World!" in result.output
+
+
+def test_fastapi_endpoint_ignores_variadic_parameters():
+    """*args / **kwargs have no HTTP equivalent.
+
+    Rewriting them to KEYWORD_ONLY produced a signature FastAPI could not
+    serve; they are dropped from the route instead.
+    """
+    from fastapi.testclient import TestClient
+
+    from intpot.runtime_builders import build_fastapi_app
+
+    app = App("variadic")
+
+    @app.tool()
+    def add(a: int, b: int, *rest: int, **opts: str) -> int:
+        """Add two numbers."""
+        return a + b
+
+    api_app: Any = build_fastapi_app("test", app._tools)
+    spec = api_app.openapi()
+    ref = spec["paths"]["/add"]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]["$ref"]
+    body_schema = spec["components"]["schemas"][ref.rsplit("/", 1)[-1]]
+
+    assert sorted(body_schema["properties"]) == ["a", "b"]
+    assert TestClient(api_app).post("/add", json={"a": 2, "b": 3}).json() == 5


### PR DESCRIPTION
Both of these are mine, found by reviewing my own merged work rather than by anything failing. Neither is a crash in normal use; both do more than they were meant to.

## 1. Variadic parameters produced an unservable route (#54)

`_fastapi_endpoint` rewrote **every** parameter to `KEYWORD_ONLY` so it could attach the `Body`/`Query`/`Header`/`Path` markers. That included `*args` and `**kwargs`, which have no HTTP equivalent — the result was a signature FastAPI couldn't serve, rather than an error saying so.

```python
@app.tool()
def add(a: int, b: int, *rest: int, **opts: str) -> int:
    return a + b
```

Variadics are now left out of the route. The wrapper never passes them, which is exactly what an empty tuple and dict amount to, and the tool's real parameters are untouched — the request body is `{a, b}` and `POST /add {"a":2,"b":3}` returns `5`.

## 2. Blank-line normalisation reached into user code (#53)

`_normalize_blank_lines` collapsed **any** run of blank lines anywhere in the output. It exists to paper over template seams, where a template's two branches don't carry the same trailing whitespace — but it also reached into preserved function bodies and docstrings and silently reformatted the source's own spacing.

It's now anchored to runs that precede a top-level statement, which is precisely where the seams are. A body that deliberately spaces itself out keeps its spacing; consecutive generated `def`s are still capped at two.

## Tests

One per fix, both fail against the merged code — verified by stashing only the two source files.

174 passed, ruff clean, pyright 0 errors.
