### PR TITLE
fix: bring the skills shipped to users up to the current API

### DIFF
--- a/changelog.d/65.fixed.md
+++ b/changelog.d/65.fixed.md
@@ -1,0 +1,4 @@
+The skills installed by `intpot add skills` now describe the current API. They had not
+been updated since 0.3.0 and covered only the conversion commands — an agent reading them
+learned nothing about `intpot.App`, `@app.tool`, `serve` or `eject`, and one example
+referenced a `ParameterInfo.annotation` field that does not exist.

--- a/src/intpot/templates/skills/intpot-cli.md
+++ b/src/intpot/templates/skills/intpot-cli.md
@@ -1,62 +1,114 @@
 # intpot CLI
 
-**intpot** converts between Typer (CLI), FastMCP (MCP), and FastAPI (API) Python apps.
+**intpot** does two things: it lets you define tools once and serve them as a Typer CLI,
+FastAPI app, or FastMCP server, and it converts existing apps between those three
+frameworks.
 
 ## When to Use
 
-Use intpot when you need to:
-- Convert a CLI app to an MCP server or REST API
-- Convert an MCP server to a CLI app or REST API
-- Convert a FastAPI app to a CLI or MCP server
-- Scaffold a new CLI, MCP, or API project
+- The user wants one set of functions available as a CLI, an HTTP API, **and** an MCP
+  server without maintaining three codebases — use `intpot.App`
+- The user has an existing Typer / FastMCP / FastAPI app and wants it in another
+  framework — use `intpot to ...`
+- The user wants to see what intpot extracts from a file before converting — use
+  `intpot inspect`
+- The user wants a new project skeleton — use `intpot init`
 
-## Commands
+## Write once, serve everywhere
 
-### Scaffold a new project
+Define tools with `@app.tool()` in a plain Python file:
 
-```bash
-intpot init <name> --type <mcp|cli|api>
+```python
+from intpot import App
+
+app = App("my-app")
+
+@app.tool()
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
 ```
 
-### Convert between frameworks
+Serve the same file in any mode:
 
 ```bash
-# MCP server -> Typer CLI
-intpot to cli server.py
+intpot serve app.py --cli          # Typer CLI
+intpot serve app.py --api          # FastAPI on 127.0.0.1:8000
+intpot serve app.py --mcp          # FastMCP server
+```
 
-# CLI app -> FastMCP server
-intpot to mcp app.py
+In `--cli` mode, arguments after the flags go to the app:
 
-# CLI app -> FastAPI app
-intpot to api app.py
+```bash
+$ intpot serve app.py --cli add 2 3
+5
+```
 
-# Write output to a file
+Use `--` when the app defines a flag intpot also defines (`--host`, `--port`):
+
+```bash
+intpot serve app.py --cli -- mytool --port 5
+```
+
+Export the same app as standalone framework code, with no intpot dependency:
+
+```bash
+intpot eject app.py --to api       # or cli, mcp
+intpot eject app.py --to cli --output cli_app.py
+```
+
+## Convert an existing app
+
+```bash
+intpot to cli server.py            # MCP or API source -> Typer CLI
+intpot to mcp app.py               # CLI or API source -> FastMCP server
+intpot to api app.py               # CLI or MCP source -> FastAPI app
+
 intpot to cli server.py --output cli_app.py
-
-# Convert all apps in a directory
-intpot to cli ./myproject/
-intpot to mcp ./myproject/ --output ./converted/
-
-# Preview without writing (dry run)
-intpot to cli server.py --dry-run
-
-# Verbose output (show detection details)
-intpot to mcp app.py --verbose
+intpot to cli ./myproject/         # every app in a directory
+intpot to cli server.py --dry-run  # print output, write nothing
+intpot to mcp app.py --verbose     # detection details on stderr
 ```
+
+## Inspect without generating
+
+```bash
+intpot inspect server.py           # table of extracted tools
+intpot inspect server.py --json    # normalized ToolInfo as JSON
+```
+
+Prefer `--json` when you need to reason about the result programmatically.
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--output`, `-o` | Output file/directory path (prints to stdout if omitted) |
-| `--verbose`, `-v` | Show detection details on stderr |
-| `--dry-run` | Preview generated code without writing files |
+| Option | Applies to | Description |
+|--------|-----------|-------------|
+| `--output`, `-o` | `to *`, `eject` | Output path (prints to stdout if omitted) |
+| `--dry-run` | `to *` | Preview generated code without writing files |
+| `--verbose`, `-v` | `to *`, `inspect` | Show detection details on stderr |
+| `--json` | `inspect` | Emit JSON instead of a table |
+| `--host` / `--port` | `serve --api` | Defaults `127.0.0.1` / `8000` |
+| `--version`, `-V` | top level | Print the installed version |
+
+## Things to know
+
+- **Detection imports the source file.** `intpot to ...` and `intpot inspect` execute the
+  module to find the app instance, so module-level code runs. Use `--dry-run` on
+  unfamiliar code.
+- **`serve --api` binds `127.0.0.1`.** Pass `--host 0.0.0.0` to expose it on the network.
+- **`serve --api` reads arguments from a JSON body**, not the query string — the same
+  shape `eject --to api` generates.
+- **Converted code carries the original body over** where the frameworks agree, and
+  rewrites it where they don't. A tool whose body can't be recovered gets a
+  `# TODO: implement` stub.
 
 ## Installation
 
 ```bash
-pip install intpot            # core (CLI conversions only)
+pip install intpot            # core: init, inspect, add skills, Typer CLI output
 pip install intpot[mcp]       # + FastMCP support
 pip install intpot[api]       # + FastAPI support
 pip install intpot[all]       # everything
 ```
+
+Extras are only needed for frameworks you actually read or emit.

--- a/src/intpot/templates/skills/intpot-python.md
+++ b/src/intpot/templates/skills/intpot-python.md
@@ -1,28 +1,67 @@
 # intpot Python API
 
-**intpot** provides a Python API for converting between Typer (CLI), FastMCP (MCP), and FastAPI (API) apps programmatically.
+**intpot** exposes two APIs: `intpot.App` for defining tools once and serving them as a
+CLI, API, or MCP server, and `intpot.load()` for converting existing framework code
+programmatically.
 
 ## When to Use
 
-Use the Python API when you need to:
-- Convert apps programmatically within scripts or pipelines
-- Inspect app functions/tools/endpoints as normalized data
-- Generate code from live app instances (not just files)
-- Integrate intpot into build tools or CI/CD
+- Define tools once and serve or export them in any framework — `App`
+- Convert apps inside scripts, build tools, or CI — `load()`
+- Read an app's functions as normalized data — `.tools`
+- Generate from a live app instance rather than a file — `load(instance)`
 
-## Core API
+## `intpot.App` — write once, serve everywhere
 
-### `intpot.load(source)`
+```python
+from intpot import App
 
-Load a file path or live app instance. Returns an `IntpotApp`.
+app = App("my-app")
+
+@app.tool()
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+```
+
+The tool's name and description default to the function name and its docstring. Override
+either — useful when the docstring explains the code to a maintainer but an agent needs
+different wording:
+
+```python
+@app.tool(name="lookup", description="Look up a customer by account number.")
+def fetch_customer_record(account_id: str) -> dict:
+    """Hit the accounts table. Caller must have validated account_id."""
+    ...
+```
+
+`async def` tools work in every mode.
+
+### Serving and exporting
+
+```python
+app.serve(mode="cli")                     # run as a Typer CLI
+app.serve(mode="api", port=8000)          # FastAPI on 127.0.0.1 by default
+app.serve(mode="api", host="0.0.0.0")     # opt in to network exposure
+app.serve(mode="mcp")                     # FastMCP server
+
+cli_code = app.eject("cli")               # standalone source, as a string
+api_code = app.eject("api")
+mcp_code = app.eject("mcp")
+```
+
+`serve(mode="api")` and `eject("api")` expose the same HTTP interface: arguments come
+from a JSON request body.
+
+## `intpot.load(source)` — convert existing code
+
+Accepts a file path or a live app instance; returns an `IntpotApp`.
 
 ```python
 import intpot
 
-# From a file path
 app = intpot.load("mcp_server.py")
 
-# From a live FastMCP instance
 from fastmcp import FastMCP
 mcp = FastMCP("my-server")
 
@@ -33,46 +72,62 @@ def greet(name: str) -> str:
 app = intpot.load(mcp)
 ```
 
-### `IntpotApp` methods
+`load()` executes the file to find the app instance — treat unfamiliar sources with the
+same caution as `exec`.
+
+### `IntpotApp`
 
 ```python
 app = intpot.load("server.py")
 
-# Generate code as strings
-cli_code = app.to_cli()
+cli_code = app.to_cli()                   # generated source, as a string
 mcp_code = app.to_mcp()
 api_code = app.to_api()
 
-# Write directly to files
-app.write("output/cli_app.py", "cli")
-app.write("output/api_app.py", "api")
-app.write("output/mcp_server.py", "mcp")
+app.write("output/cli_app.py", "cli")     # generate and write, returns the Path
 
-# Inspect normalized tools
-for tool in app.tools:
-    print(tool.name, tool.description)
-    for param in tool.parameters:
-        print(f"  {param.name}: {param.annotation} = {param.default}")
-
-# Check detected source type
-print(app.source_type)  # SourceType.MCP, SourceType.CLI, or SourceType.API
+print(app.source_type)                    # SourceType.MCP / CLI / API
 ```
+
+Calling `to_cli()` on a source that is already a CLI raises `ValueError`; same for the
+other two.
+
+## Normalized tool data
+
+`.tools` returns `ToolInfo` objects — the schema both halves of intpot meet at.
+
+```python
+for tool in app.tools:
+    print(tool.name, tool.description, tool.return_type, tool.is_async)
+    for param in tool.parameters:
+        print(f"  {param.name}: {param.type_annotation}")
+        print(f"    required={param.required} default={param.default}")
+```
+
+`ToolInfo` fields: `name`, `description`, `parameters`, `return_type`, `http_method`,
+`function_body`, `is_async`, `route_path`, `dependencies`, `source_imports`.
+
+`ParameterInfo` fields: `name`, `type_annotation`, `default`, `description`,
+`param_source`, plus a `required` property. **The type field is `type_annotation`, not
+`annotation`.** `default` is a private sentinel when the parameter is required — check
+`param.required` rather than comparing against `None`.
+
+`param_source` is `ParamSource.query` / `header` / `path` / `body` for FastAPI sources
+that declared one, otherwise `None`.
 
 ### `intpot.inspect_app(source_type, app_instance)`
 
-Low-level inspection — extract `ToolInfo` list from a live app instance.
+Low-level: extract `ToolInfo` from a live instance without wrapping it.
 
 ```python
 from intpot import inspect_app
 from intpot.core.models import SourceType
 
 tools = inspect_app(SourceType.MCP, mcp_instance)
-for tool in tools:
-    print(tool.name, [p.name for p in tool.parameters])
 ```
 
 ## Installation
 
-```python
-pip install intpot[all]  # includes fastmcp + fastapi extras
+```bash
+pip install intpot[all]   # includes the fastmcp and fastapi extras
 ```

--- a/tests/test_skills_content.py
+++ b/tests/test_skills_content.py
@@ -1,0 +1,76 @@
+"""The skills shipped by `intpot add skills` must describe the current API.
+
+These files land in other people's projects and are read by their coding agents,
+so a stale one actively teaches the wrong thing. They sat at the v0.3.0 API for
+five months without anything noticing.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+
+from intpot.core.models import ParameterInfo, ToolInfo
+from intpot.skills.content import cli_skill_body, python_skill_body
+
+
+def _all_skill_text() -> str:
+    return cli_skill_body() + "\n" + python_skill_body()
+
+
+def test_skills_cover_the_runtime_api():
+    """The App runtime is the headline feature — it must not be missing again."""
+    text = _all_skill_text()
+
+    for symbol in ("intpot.App", "@app.tool", "app.serve", "eject"):
+        assert symbol in text, f"skills never mention {symbol}"
+
+
+def test_skills_cover_the_conversion_api():
+    text = _all_skill_text()
+
+    for symbol in ("intpot.load", "to_cli", "to_mcp", "to_api", "intpot to cli"):
+        assert symbol in text, f"skills never mention {symbol}"
+
+
+def test_skills_cover_every_cli_command():
+    text = _all_skill_text()
+
+    for command in ("intpot init", "intpot inspect", "intpot serve", "intpot eject"):
+        assert command in text, f"skills never mention `{command}`"
+
+
+def test_skills_only_reference_real_parameter_fields():
+    """Catches the reverse failure: documenting an attribute that never existed.
+
+    The old skill printed `param.annotation`, which is spelled
+    `type_annotation` — anyone following it got an AttributeError.
+    """
+    valid = {f.name for f in dataclasses.fields(ParameterInfo)} | {"required"}
+
+    referenced = set(re.findall(r"\bparam\.(\w+)", _all_skill_text()))
+
+    assert referenced, "expected the skills to show ParameterInfo usage"
+    assert referenced <= valid, f"not real ParameterInfo fields: {referenced - valid}"
+
+
+def test_skills_only_reference_real_tool_fields():
+    valid = {f.name for f in dataclasses.fields(ToolInfo)}
+
+    referenced = set(re.findall(r"\btool\.(\w+)", _all_skill_text()))
+
+    assert referenced, "expected the skills to show ToolInfo usage"
+    assert referenced <= valid, f"not real ToolInfo fields: {referenced - valid}"
+
+
+def test_skills_do_not_promise_the_old_network_default():
+    """serve --api binds loopback since 0.5.0."""
+    text = _all_skill_text()
+
+    assert "127.0.0.1" in text
+    # 0.0.0.0 may only appear as the documented opt-in, never as the default.
+    for line in text.splitlines():
+        if "0.0.0.0" in line:
+            assert re.search(r"opt|expose|network|host=", line), (
+                f"0.0.0.0 mentioned without framing it as opt-in: {line!r}"
+            )


### PR DESCRIPTION
## The problem

`intpot add skills` installs `intpot-cli.md` and `intpot-python.md` into other people's projects, where their coding agents read them as authoritative. Both were last touched **2026-03-26** — the v0.3.0 API.

| term | mentions in either file |
|------|------------------------|
| `App(` | 0 |
| `@app.tool` | 0 |
| `eject` | 0 |

The `intpot.App` runtime landed in 0.4.0 on 7 April. So for five months, every `intpot add skills` has taught agents the converter and **nothing about the feature the README leads with**. An agent working from these would never suggest `App`, `serve`, or `eject`.

The Python skill also had a straightforward bug:

```python
print(f"  {param.name}: {param.annotation} = {param.default}")
```

`ParameterInfo` has `type_annotation`, not `annotation`. Anyone following that example got an `AttributeError`.

## What changed

Both rewritten for 0.5.0 — the App runtime and both `@app.tool` overrides, `serve` with argument passthrough and the `--` escape, `eject`, `inspect` including `--json`, `--dry-run`/`--verbose`, the real `ToolInfo`/`ParameterInfo` field lists, the loopback default, and the warning that detection executes the source file.

Verified end to end by running `intpot add skills` into a scratch project and reading what landed.

## Stopping the rot

`tests/test_skills_content.py` asserts the skills mention the runtime API, the conversion API, and every CLI command — and the reverse failure, that every `param.x` and `tool.x` they reference is a real dataclass field, derived from `dataclasses.fields()` so it tracks the models automatically.

**Four of its six tests fail against the old files**, including the one that catches `param.annotation`.

There's a `sync-skills` skill in `.claude/` written to prevent exactly this drift. It's untracked, so it never ran for anyone. A test runs on every PR.

191 passed, ruff clean, pyright 0 errors.

---

## ⚠️ Separate bug found while testing this

`intpot add skills --agent claude` writes files Claude Code will never load.

It writes `.claude/skills/intpot-cli.md` — a flat file with no frontmatter, since `claude_skill()` returns the body unchanged. Claude Code discovers skills as `.claude/skills/<name>/SKILL.md` with YAML frontmatter carrying `name` and `description`.

**This repo's own `.claude/skills/` proves the format** — `sync-skills/SKILL.md` has exactly that layout and frontmatter.

So for Claude Code, the first agent in the supported list, the feature has never worked. The other five look right: Cursor gets proper `.mdc` frontmatter, Codex gets `AGENTS.md`, Copilot gets `.github/copilot-instructions.md`.

Not fixed here — it changes file layout, the README's agent table, and the installer tests, and this PR is about content. Worth doing next.
