### PR TITLE
docs: bring the roadmap back in line with what shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,30 +1,62 @@
 # Roadmap
 
-## v0.4 (current) — Write Once, Serve Everywhere
+## v0.5 (current) — Write Once, Serve Everywhere
 
-intpot v0.4 adds the `App` runtime framework: define tools once with `@app.tool()` and serve them as CLI, API, or MCP server with a single command. Eject to standalone framework code at any time.
+Define tools once with `@app.tool()` and serve them as a CLI, API, or MCP server, or
+eject them to standalone framework code. The converter handles all six directions between
+existing Typer, FastMCP, and FastAPI apps.
 
 ### Remaining polish
 
-- [ ] Handle `Annotated[str, Body(...)]` style FastAPI parameters
-- [ ] Support Click groups / Typer sub-apps (nested command hierarchies)
-- [ ] Preserve parameter descriptions through all conversion directions
-- [ ] `--all` mode for `intpot serve` — serve CLI, API, and MCP simultaneously
+- [ ] Handle `Annotated[str, Body(...)]` style FastAPI parameters ([#1](https://github.com/tugrulguner/intpot/issues/1))
+- [ ] Support Click groups / Typer sub-apps, i.e. nested command hierarchies ([#2](https://github.com/tugrulguner/intpot/issues/2))
+- [ ] Preserve parameter descriptions through all conversion directions ([#3](https://github.com/tugrulguner/intpot/issues/3), [#9](https://github.com/tugrulguner/intpot/issues/9))
+- [ ] `--all` mode for `intpot serve` — serve CLI, API, and MCP simultaneously ([#32](https://github.com/tugrulguner/intpot/issues/32))
+
+## Already shipped
+
+These were listed as v2 goals when this roadmap was first written, and landed earlier
+than planned:
+
+- **Basic body transforms** — `typer.echo(x)` becomes `return x` on the way to MCP/API
+  and back again, and `raise typer.Exit(code)` becomes `raise RuntimeError(...)`. See
+  `core/transforms.py`.
+- **Return-type coercion for FastAPI** — a scalar return is wrapped as
+  `{"result": ...}` so the generated handler matches the response model FastAPI validates
+  against.
+- **Round-trip fidelity tests** — `tests/test_roundtrip.py` covers all three pairings.
+- **Direct import resolution** — imports referenced by a function body are carried into
+  the generated file. Transitive dependencies are not yet followed.
 
 ## v2 — Full AST Transform Pipeline
 
-v2 will introduce a proper AST-based transformation stage that rewrites function bodies between frameworks, not just signatures.
+v2 goes past the signature-level and single-call rewrites that exist today, into
+transformations that need real understanding of what a function body does.
 
-### Planned features
+### Planned
 
-- **Deep body transforms** — rewrite framework-specific calls in function bodies (e.g. `typer.echo()` → `return`, `raise typer.Exit()` → `raise RuntimeError()`, request/response pattern adaption)
-- **Import graph resolution** — full analysis of what the function body actually needs, including transitive imports and third-party dependencies
-- **Dependency injection mapping** — convert FastAPI `Depends()` into equivalent patterns in CLI/MCP (e.g. setup/teardown, context managers)
-- **Error handling conversion** — map between `typer.Exit`/`typer.Abort`, HTTP exceptions, and MCP error patterns
-- **Type coercion layer** — automatically adapt return types and serialization between frameworks (dicts ↔ strings ↔ Pydantic models)
-- **Round-trip fidelity tests** — verify that `A → B → A` produces functionally equivalent code
+- **Deep body transforms** ([#19](https://github.com/tugrulguner/intpot/issues/19)) —
+  beyond the `typer.echo`/`typer.Exit` pairs already handled: request/response pattern
+  adaptation, framework-specific context objects, streaming and background-task idioms
+- **Dependency injection mapping** ([#20](https://github.com/tugrulguner/intpot/issues/20)) —
+  FastAPI `Depends()` is currently recorded as a comment in the generated file; v2 should
+  convert it into the target's equivalent, such as a context manager or setup/teardown
+- **Pydantic model parameters** ([#17](https://github.com/tugrulguner/intpot/issues/17)) —
+  expand a model argument into individual CLI/MCP parameters instead of treating it as one
+  opaque value
+- **Transitive import resolution** — follow what the body's own dependencies need, not
+  just the names it mentions directly
+- **Full error-handling conversion** — Typer exits are mapped today; HTTP exceptions and
+  MCP error patterns are not
 
 ### Non-goals for v2
 
 - Runtime interop / adapter layer (intpot is a code generator, not a runtime bridge)
 - Supporting frameworks beyond Typer, FastMCP, and FastAPI
+
+---
+
+Every item above is tracked as an issue. If something here interests you,
+[CONTRIBUTING.md](CONTRIBUTING.md) has the setup and
+[good first issues](https://github.com/tugrulguner/intpot/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+are a gentler place to start.

--- a/changelog.d/68.changed.md
+++ b/changelog.d/68.changed.md
@@ -1,0 +1,3 @@
+The roadmap now reflects what is built. It described basic body transforms, return-type
+coercion, round-trip tests and import resolution as future v2 work months after they
+shipped, and still labelled 0.4 as current. Remaining items link to their issues.


### PR DESCRIPTION
`ROADMAP.md` was last touched **2026-04-07** — the 0.4.0 commit. It still said "v0.4 (current)" after 0.5.0 went out, but the version label is the least of it.

## It listed shipped features as future work

Four items under "v2 — Planned features" already work. Two of them are described using the exact examples the code implements:

| ROADMAP said "planned for v2" | Actually in the codebase |
|---|---|
| *"`typer.echo()` → `return`, `raise typer.Exit()` → `raise RuntimeError()`"* | `_TyperEchoToReturn`, `_TyperExitTransformer` |
| Type coercion between frameworks | `_wrap_returns_in_dict`, shipped in #56 |
| Round-trip fidelity tests | `tests/test_roundtrip.py`, all three pairings |
| Import graph resolution | `extract_source_imports` — direct imports only |

So someone evaluating intpot read that body rewriting was a future ambition when it's been working for months. The README had the opposite problem — claiming more than it did. This claimed less.

Issue #19 already described the true state — *"currently intpot only transforms basic patterns like `typer.echo() ↔ return`"* — so the roadmap was the only document out of step with both the code and the tracker.

## Changes

Those four move to an **Already shipped** section. The genuinely unbuilt parts stay in v2, narrowed to what's actually left:

- deeper body rewrites *beyond* the two pairs already handled (#19)
- **transitive** imports, rather than the direct ones that work today
- HTTP and MCP error patterns, rather than just Typer exits

Dependency injection (#20) and Pydantic model expansion (#17) join v2 — both were real gaps not previously listed. `Depends()` is currently only recorded as a comment in generated output.

Every remaining item links to its issue, so the roadmap and the tracker stop being two independent lists that drift apart.

The polish list was accurate; only its heading changed.

## The forcing function

The release process gains a step: after `make changelog`, check whether anything in the assembled section came off the roadmap, and bump the "(current)" heading.

That's deliberately a checklist item rather than a test. **No assertion can catch this** — you can prove a feature exists, but not that a document still calls it unbuilt, and inverting it into "assert this is still unimplemented" is a test that fails when you succeed. Reading the assembled changelog is the one moment someone is already looking at exactly what shipped, so the question belongs there.

This PR originally added that step to `CONTRIBUTING.md`. #69 moves the whole Releasing section out of `CONTRIBUTING.md` into `docs/releasing.md` — contributors can't bump versions or push tags, so it never belonged in a contributor doc — which would have put the same instruction in two files and conflicted on merge. The wording from here was carried into `docs/releasing.md` in #69 and dropped from this branch, so this PR is now `ROADMAP.md` and its changelog fragment only. The two can merge in either order.

## Verification

Every claim in the "Already shipped" section checked against the source, and all eight linked issues confirmed open. 185 tests pass.

