### PR TITLE
fix: stop dropping FastAPI endpoints named `root`

### DIFF
--- a/changelog.d/70.fixed.md
+++ b/changelog.d/70.fixed.md
@@ -1,0 +1,4 @@
+FastAPI endpoints named `root` are no longer dropped during conversion. Built-in routes
+were filtered by function name and `root` was on that list, so the usual handler for `/`
+silently disappeared from every conversion. FastAPI's own documentation routes are now
+excluded by route type instead, which is exact.

--- a/src/intpot/core/inspectors/api.py
+++ b/src/intpot/core/inspectors/api.py
@@ -15,14 +15,6 @@ from intpot.core.inspectors._utils import (
 from intpot.core.inspectors.base import BaseInspector
 from intpot.core.models import _SENTINEL, ParameterInfo, ParamSource, ToolInfo
 
-_INTERNAL_ROUTES = {
-    "openapi",
-    "swagger_ui_html",
-    "swagger_ui_redirect",
-    "redoc_html",
-    "root",
-}
-
 _PATH_PARAM_RE = re.compile(r"\{(\w+)\}")
 
 
@@ -57,18 +49,23 @@ def _get_param_source(obj: Any) -> ParamSource | None:
 
 class APIInspector(BaseInspector):
     def inspect(self, app: Any) -> list[ToolInfo]:
+        # Local import: fastapi is an optional extra, and this method only runs
+        # once a FastAPI app has already been detected.
+        from fastapi.routing import APIRoute
+
         tools: list[ToolInfo] = []
 
         for route in app.routes:
-            if not hasattr(route, "endpoint"):
+            # Only the user's own endpoints are APIRoute. FastAPI registers its
+            # docs endpoints (/openapi.json, /docs, /redoc) as plain Starlette
+            # Routes, so this excludes them exactly. Filtering by function name
+            # instead used to drop any endpoint the user happened to call
+            # `root` — i.e. the usual handler for `/`.
+            if not isinstance(route, APIRoute):
                 continue
 
             endpoint = route.endpoint
             name = endpoint.__name__
-
-            # Skip FastAPI's built-in routes
-            if name in _INTERNAL_ROUTES:
-                continue
 
             description = endpoint.__doc__ or ""
             description = description.strip()

--- a/tests/test_inspectors/test_api_inspector.py
+++ b/tests/test_inspectors/test_api_inspector.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import FastAPI
 
 from intpot.core.inspectors.api import APIInspector
@@ -162,3 +164,74 @@ def test_generator_output_correct_fastapi_types():
     assert "Header" in output
     assert "q: str = Query(" in output
     assert "token: str = Header(" in output
+
+
+def test_an_endpoint_named_root_is_not_dropped():
+    """`@app.get("/") def root()` is the usual handler for `/`.
+
+    Built-in routes used to be filtered by function name, and `root` was on that
+    list, so the most common endpoint in FastAPI silently vanished from every
+    conversion.
+    """
+    app = FastAPI()
+
+    @app.get("/")
+    def root() -> dict:
+        """The landing endpoint."""
+        return {"message": "hello"}
+
+    @app.get("/health")
+    def health() -> dict:
+        """Health check."""
+        return {"ok": True}
+
+    tools = APIInspector().inspect(app)
+
+    assert sorted(t.name for t in tools) == ["health", "root"]
+
+
+def test_fastapi_own_documentation_routes_are_excluded():
+    """/openapi.json, /docs and /redoc are FastAPI's, not the user's."""
+    app = FastAPI()
+
+    @app.post("/work")
+    def work(x: int) -> dict:
+        """Do work."""
+        return {"x": x}
+
+    tools = APIInspector().inspect(app)
+
+    assert [t.name for t in tools] == ["work"]
+    assert not {"openapi", "swagger_ui_html", "redoc_html"} & {t.name for t in tools}
+
+
+def test_a_root_endpoint_survives_conversion_and_runs():
+    """The generated CLI must actually expose and execute the root command."""
+    import typer
+    from typer.testing import CliRunner
+
+    from intpot.core.generators.cli import CLIGenerator
+    from intpot.core.models import SourceType
+    from intpot.core.transforms import transform_tools
+
+    app = FastAPI()
+
+    @app.get("/")
+    def root(name: str) -> dict:
+        """Greet from the landing endpoint."""
+        return {"message": f"hello {name}"}
+
+    @app.get("/health")
+    def health() -> dict:
+        """Second command, so Typer keeps a named command group."""
+        return {"ok": True}
+
+    tools = transform_tools(APIInspector().inspect(app), SourceType.API, SourceType.CLI)
+    namespace: dict[str, Any] = {}
+    exec(compile(CLIGenerator().generate(tools), "<generated>", "exec"), namespace)
+
+    result = CliRunner().invoke(namespace["app"], ["root", "world"])
+
+    assert result.exit_code == 0, result.output
+    assert "hello world" in result.output
+    assert isinstance(namespace["app"], typer.Typer)


### PR DESCRIPTION
`@app.get("/")` with a handler named `root` is the most common endpoint in FastAPI. intpot silently dropped it from every conversion.

## Cause

`core/inspectors/api.py` filtered built-in routes by **function name**:

```python
_INTERNAL_ROUTES = {"openapi", "swagger_ui_html", "swagger_ui_redirect", "redoc_html", "root"}
```

The first four are FastAPI's. `root` is not — it's the user's. Any app with one lost that endpoint with no warning:

```
$ intpot inspect app.py        # app has root() and health()
tools found: ['health']
```

## Fix

FastAPI registers its documentation endpoints (`/openapi.json`, `/docs`, `/docs/oauth2-redirect`, `/redoc`) as plain `starlette.routing.Route`. Every user endpoint is a `fastapi.routing.APIRoute`. That's the real discriminator, so the name list isn't needed at all:

```python
if not isinstance(route, APIRoute):
    continue
```

Verified against a live app — the four doc routes are `Route`, the user's are `APIRoute`. The import is local because `fastapi` is an optional extra and this method only runs after a FastAPI app has been detected.

## Tests

- `test_an_endpoint_named_root_is_not_dropped` — the direct regression.
- `test_fastapi_own_documentation_routes_are_excluded` — guards the other direction, so the fix can't over-correct into emitting `/docs` as a tool.
- `test_a_root_endpoint_survives_conversion_and_runs` — converts to a Typer CLI, `exec`s the generated module and invokes `root world`, asserting on real output. The bug was invisible to string assertions, so this one executes the result.

Two of the three fail on `main`; the doc-routes test is a regression guard and passes either way.

`make check` green: 256 passed.
