### PR TITLE
fix: extract one-line function bodies without the signature

### DIFF
--- a/changelog.d/71.fixed.md
+++ b/changelog.d/71.fixed.md
@@ -1,0 +1,3 @@
+Tools written on a single line — `def double(x: int) -> int: return x * 2` — now convert
+correctly. The extracted body included the `def` line itself, so the generated command or
+endpoint defined a nested function and never called it, producing no output at all.

--- a/src/intpot/core/inspectors/_utils.py
+++ b/src/intpot/core/inspectors/_utils.py
@@ -108,19 +108,32 @@ def extract_function_body(fn: Any) -> str | None:
     func_node = tree.body[0]
     lines = source.splitlines()
 
-    # Find where the body starts (skip decorator lines and def line)
-    body_start_line = func_node.body[0].lineno  # 1-indexed
-
-    # If the first body statement is a docstring, skip it
+    # Find the first real statement, skipping a leading docstring
     first_stmt = func_node.body[0]
     if isinstance(first_stmt, ast.Expr) and isinstance(
         first_stmt.value, (ast.Constant, ast.Str)
     ):
         if len(func_node.body) <= 1:
             return None  # Only a docstring, no real body
-        body_start_line = func_node.body[1].lineno
+        first_stmt = func_node.body[1]
 
-    body_lines = lines[body_start_line - 1 :]
+    line_index = first_stmt.lineno - 1  # lineno is 1-indexed
+    if line_index >= len(lines):
+        return None
+
+    # `def double(x): return x * 2` puts the body on the signature's own line, so
+    # slicing whole lines would swallow the `def` and produce a nested function
+    # that nothing ever calls. Anything before the statement on that line that
+    # isn't indentation means the line is shared, so start at the statement.
+    before_stmt = lines[line_index][: first_stmt.col_offset]
+    if before_stmt.strip():
+        body_lines = [
+            lines[line_index][first_stmt.col_offset :],
+            *lines[line_index + 1 :],
+        ]
+    else:
+        body_lines = lines[line_index:]
+
     if not body_lines:
         return None
 

--- a/tests/test_inspectors/test_utils.py
+++ b/tests/test_inspectors/test_utils.py
@@ -1,0 +1,118 @@
+"""Tests for the shared inspector utilities.
+
+The one-liner cases are written into real files rather than defined inline,
+because ruff-format would rewrite `def f(): return 1` into two lines and quietly
+delete the thing being tested.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from intpot.core.generators.cli import CLIGenerator
+from intpot.core.inspectors._utils import extract_function_body
+from intpot.core.models import SourceType
+from intpot.core.transforms import transform_tools
+
+
+def _load(path: Path, name: str) -> Any:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, name)
+
+
+def test_body_on_the_signature_line_excludes_the_signature(tmp_source):
+    """`def double(x): return x * 2` must yield `return x * 2`, not the def line.
+
+    Slicing whole lines used to include the signature, so the generated code
+    defined a nested function and never called it — valid Python that did
+    nothing.
+    """
+    path = tmp_source("def double(x: int) -> int: return x * 2\n")
+
+    assert extract_function_body(_load(path, "double")) == "return x * 2"
+
+
+def test_multi_line_body_is_unchanged(tmp_source):
+    path = tmp_source(
+        """
+        def triple(x: int) -> int:
+            y = x * 3
+            return y
+        """
+    )
+
+    assert extract_function_body(_load(path, "triple")) == "y = x * 3\nreturn y"
+
+
+def test_docstring_is_skipped(tmp_source):
+    path = tmp_source(
+        '''
+        def doc(x: int) -> int:
+            """Docstring."""
+            return x
+        '''
+    )
+
+    assert extract_function_body(_load(path, "doc")) == "return x"
+
+
+def test_statement_sharing_a_line_with_the_docstring(tmp_source):
+    path = tmp_source('def d(x: int) -> int:\n    """Doc."""; return x\n')
+
+    assert extract_function_body(_load(path, "d")) == "return x"
+
+
+def test_docstring_only_function_has_no_body(tmp_source):
+    path = tmp_source(
+        '''
+        def stub(x: int) -> int:
+            """Nothing here."""
+        '''
+    )
+
+    assert extract_function_body(_load(path, "stub")) is None
+
+
+def test_a_one_line_tool_still_runs_after_conversion(tmp_source):
+    """End to end: the generated CLI must actually compute, not silently pass."""
+    path = tmp_source(
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("probe")\n'
+        "\n"
+        "@mcp.tool()\n"
+        "def double(x: int) -> int: return x * 2\n"
+        "\n"
+        "@mcp.tool()\n"
+        "def triple(x: int) -> int:\n"
+        "    return x * 3\n"
+    )
+
+    from intpot import load
+
+    tools = transform_tools(load(path).tools, SourceType.MCP, SourceType.CLI)
+    namespace: dict[str, Any] = {}
+    exec(compile(CLIGenerator().generate(tools), "<generated>", "exec"), namespace)
+
+    result = CliRunner().invoke(namespace["app"], ["double", "4"])
+
+    assert result.exit_code == 0, result.output
+    assert "8" in result.output
+
+
+def test_the_generated_body_contains_no_nested_definition(tmp_source):
+    """The specific corruption: a `def` smuggled into the body."""
+    path = tmp_source("def double(x: int) -> int: return x * 2\n")
+
+    body = extract_function_body(_load(path, "double"))
+
+    assert body is not None
+    assert "def " not in body


### PR DESCRIPTION
A tool written on one line — `def double(x: int) -> int: return x * 2` — converted into generated code that silently did nothing.

## Cause

`_utils.extract_function_body` located the body by line number and sliced from there:

```python
body_start_line = func_node.body[0].lineno
body_lines = lines[body_start_line - 1:]
```

For a one-liner, `body[0].lineno` **is** the `def` line, so the signature came along with it. The result:

```python
def _double_impl(x: int) -> None:
    """"""
    def double(x: int) -> int:      # nested, never called
        return x * 2
```

Syntactically valid, which is why every existing test passed — they assert on the generated string. Run it and the command produces no output.

## Fix

The first statement's `col_offset` tells you whether it shares a line with the signature. Anything before it on that line that isn't indentation means it does, so the body starts at that column rather than at the start of the line:

```python
before_stmt = lines[line_index][: first_stmt.col_offset]
if before_stmt.strip():
    body_lines = [lines[line_index][first_stmt.col_offset:], *lines[line_index + 1:]]
else:
    body_lines = lines[line_index:]
```

Multi-line bodies take the unchanged path. The same logic also fixes a statement sharing a line with the docstring (`"""Doc."""; return x`).

## Tests

New `tests/test_inspectors/test_utils.py` — the module had no tests at all.

- `test_body_on_the_signature_line_excludes_the_signature` — the direct regression.
- `test_the_generated_body_contains_no_nested_definition` — asserts the specific corruption is gone.
- `test_a_one_line_tool_still_runs_after_conversion` — converts MCP → CLI, `exec`s the generated module, invokes `double 4` and asserts on `8`. This is the one that would have caught the bug.
- `test_statement_sharing_a_line_with_the_docstring` — the related case.
- Plus unchanged-behaviour guards for multi-line bodies, docstring skipping, and docstring-only functions.

The one-liners are written into real files via the `tmp_source` fixture rather than defined inline, because ruff-format would rewrite `def f(): return 1` onto two lines and quietly delete the thing under test.

Four of the seven fail on `main`.

`make check` green: 260 passed.
