### PR TITLE
fix: stop `add skills` firing on repos that use no agent

### DIFF
--- a/changelog.d/72.fixed.md
+++ b/changelog.d/72.fixed.md
@@ -1,0 +1,5 @@
+`intpot add skills` no longer installs into projects that use no AI agent. `.github/` was
+treated as evidence of Copilot and `AGENTS.md` as evidence of Codex, so an ordinary repo
+with a CI workflow had intpot's skills appended to its own AGENTS.md. Copilot is now
+detected from `.github/copilot-instructions.md`, and Codex must be requested with
+`--agent codex`.

--- a/src/intpot/commands/add_skills.py
+++ b/src/intpot/commands/add_skills.py
@@ -23,9 +23,6 @@ from intpot.skills.content import (
 # Per-agent writers
 # ---------------------------------------------------------------------------
 
-_WRITERS: dict[Agent, tuple] = {}  # populated below
-
-
 _CLAUDE_SKILLS = (
     (
         "intpot-cli",
@@ -177,24 +174,36 @@ _AGENT_WRITERS: dict[Agent, Callable[..., list[Path]]] = {
     Agent.codex: _write_codex,
 }
 
-# Folders whose presence signals that an agent is in use
+# Paths whose presence means the agent is actually configured for this project.
+# These are deliberately specific. `.github/` only means the project is on
+# GitHub, and a bare `AGENTS.md` is a cross-tool convention that most repos now
+# have for reasons unrelated to Codex — detecting on either matched ordinary
+# repositories using no agent at all, and both writers *append*, so a plain CI
+# repo had hundreds of lines added to its own AGENTS.md.
 _AGENT_MARKERS: dict[Agent, str] = {
     Agent.claude: ".claude",
     Agent.cursor: ".cursor",
     Agent.windsurf: ".windsurf",
-    Agent.copilot: ".github",
+    Agent.copilot: ".github/copilot-instructions.md",
     Agent.cline: ".clinerules",
-    Agent.codex: "AGENTS.md",
 }
+
+# Codex reads AGENTS.md, but so does nearly everything else, so its presence is
+# not evidence of Codex. There is no project-level marker that is: the Codex CLI
+# keeps its configuration in the user's home directory. Ask for it by name.
+_REQUIRES_EXPLICIT_REQUEST = (Agent.codex,)
 
 
 def _detect_agents(root: Path) -> list[Agent]:
-    """Auto-detect which agents are configured in the project."""
-    found: list[Agent] = []
-    for agent, marker in _AGENT_MARKERS.items():
-        if (root / marker).exists():
-            found.append(agent)
-    return found
+    """Auto-detect which agents are configured in the project.
+
+    Only agents with an unambiguous project-level marker are detected. Missing
+    one is recoverable with --agent; guessing wrong silently edits files the
+    user never asked to touch.
+    """
+    return [
+        agent for agent, marker in _AGENT_MARKERS.items() if (root / marker).exists()
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -232,9 +241,12 @@ def add_skills(
     else:
         agents = _detect_agents(root)
         if not agents:
+            explicit = ", ".join(a.value for a in _REQUIRES_EXPLICIT_REQUEST)
             typer.echo(
                 "No AI coding agents detected. Use --agent to specify one "
-                "(claude, cursor, windsurf, copilot, cline, codex).",
+                "(claude, cursor, windsurf, copilot, cline, codex).\n"
+                f"Note: {explicit} is never auto-detected — AGENTS.md is a "
+                "cross-tool convention, so its presence does not imply it.",
                 err=True,
             )
             raise typer.Exit(1)

--- a/tests/test_commands/test_add_skills.py
+++ b/tests/test_commands/test_add_skills.py
@@ -70,9 +70,10 @@ def test_add_skills_auto_detect_windsurf(tmp_path: Path, monkeypatch):
 
 
 def test_add_skills_auto_detect_copilot(tmp_path: Path, monkeypatch):
-    """Auto-detect Copilot when .github/ exists."""
+    """Auto-detect Copilot from its instructions file, not from `.github/`."""
     monkeypatch.chdir(tmp_path)
     (tmp_path / ".github").mkdir()
+    (tmp_path / ".github" / "copilot-instructions.md").write_text("# Existing\n")
 
     result = runner.invoke(app, ["add", "skills"])
     assert result.exit_code == 0
@@ -97,14 +98,21 @@ def test_add_skills_auto_detect_cline(tmp_path: Path, monkeypatch):
     assert (tmp_path / ".clinerules" / "intpot-python.md").exists()
 
 
-def test_add_skills_auto_detect_codex(tmp_path: Path, monkeypatch):
-    """Auto-detect Codex when AGENTS.md exists."""
+def test_add_skills_codex_requires_an_explicit_request(tmp_path: Path, monkeypatch):
+    """AGENTS.md is a cross-tool convention, so it cannot imply Codex.
+
+    It used to, and because the Codex writer appends, any project with an
+    AGENTS.md had intpot's skills added to its own documentation.
+    """
     monkeypatch.chdir(tmp_path)
     (tmp_path / "AGENTS.md").write_text("# Existing agents\n")
 
-    result = runner.invoke(app, ["add", "skills"])
-    assert result.exit_code == 0
-    assert "codex" in result.output
+    auto = runner.invoke(app, ["add", "skills"])
+    assert auto.exit_code == 1
+    assert (tmp_path / "AGENTS.md").read_text() == "# Existing agents\n"
+
+    explicit = runner.invoke(app, ["add", "skills", "--agent", "codex"])
+    assert explicit.exit_code == 0
 
     content = (tmp_path / "AGENTS.md").read_text()
     assert "# Existing agents" in content  # preserved
@@ -276,3 +284,73 @@ def test_claude_skills_carry_discoverable_frontmatter(tmp_path: Path, monkeypatc
         assert len(description) > 60, f"{name} description is too thin to match on"
         assert "intpot" in description
         assert body.strip().startswith("# intpot")
+
+
+# ---------------------------------------------------------------------------
+# Detection must not fire on ordinary repositories
+# ---------------------------------------------------------------------------
+
+
+def test_an_ordinary_github_repo_is_not_mistaken_for_copilot_and_codex(
+    tmp_path: Path, monkeypatch
+):
+    """A CI workflow and an AGENTS.md are not evidence of any agent.
+
+    `.github/` was the Copilot marker and `AGENTS.md` the Codex one, so a repo
+    using no AI tooling at all matched both — and since both writers append,
+    248 lines were added to the project's own AGENTS.md.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    (tmp_path / ".github" / "workflows" / "ci.yml").write_text("name: ci\n")
+    original = "# AGENTS.md\n\nMy project guidance.\n"
+    (tmp_path / "AGENTS.md").write_text(original)
+
+    result = runner.invoke(app, ["add", "skills"])
+
+    assert result.exit_code == 1
+    assert "No AI coding agents detected" in result.output
+    assert (tmp_path / "AGENTS.md").read_text() == original
+    assert not (tmp_path / ".github" / "copilot-instructions.md").exists()
+
+
+def test_a_github_directory_alone_does_not_imply_copilot(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".github").mkdir()
+
+    result = runner.invoke(app, ["add", "skills"])
+
+    assert result.exit_code == 1
+    assert not (tmp_path / ".github" / "copilot-instructions.md").exists()
+
+
+def test_every_auto_detected_marker_is_agent_specific(tmp_path: Path, monkeypatch):
+    """Each marker must appear only when that agent is configured.
+
+    Creating one marker must select exactly one agent — no marker may be a path
+    that projects create for unrelated reasons.
+    """
+    from intpot.commands.add_skills import _AGENT_MARKERS, _detect_agents
+
+    for agent, marker in _AGENT_MARKERS.items():
+        root = tmp_path / agent.value
+        target = root / marker
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if Path(marker).suffix:
+            target.write_text("# marker\n")
+        else:
+            target.mkdir(exist_ok=True)
+
+        assert _detect_agents(root) == [agent], f"{marker} selected the wrong agents"
+
+
+def test_explicitly_requested_agents_still_bypass_detection(
+    tmp_path: Path, monkeypatch
+):
+    """--agent is the escape hatch for anything detection misses."""
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["add", "skills", "--agent", "copilot"])
+
+    assert result.exit_code == 0
+    assert (tmp_path / ".github" / "copilot-instructions.md").exists()


### PR DESCRIPTION
`intpot add skills` with no `--agent` modified projects that use no AI tooling at all.

## Cause

`commands/add_skills.py` detected agents from marker paths:

```python
Agent.copilot: ".github",
Agent.codex:   "AGENTS.md",
```

Neither is evidence of an agent. `.github/` means the project is on GitHub. `AGENTS.md` is a cross-tool convention that most repositories now have for reasons unrelated to Codex — intpot's own repo is an example.

Both of those writers **append** rather than create. Reproduced on a directory containing nothing but `.github/workflows/ci.yml` and a hand-written `AGENTS.md`:

```
$ intpot add skills
  ✓ .github/copilot-instructions.md
  ✓ AGENTS.md

Installed intpot skills for 2 agent(s): copilot, codex
```

The project's own `AGENTS.md` went from 3 lines to 251.

## Fix

- **Copilot** is detected from `.github/copilot-instructions.md` — the file Copilot actually reads.
- **Codex** is no longer auto-detected. The Codex CLI keeps its configuration in the user's home directory, so no project-level path means "Codex" and nothing else. `--agent codex` still works, and the error message now explains why it must be asked for by name.

The trade is deliberate: a missed agent is recoverable with `--agent`, while a false positive silently edits files the user never asked to touch.

Also removes `_WRITERS`, an empty dict annotated "populated below" that nothing ever read.

## Tests

- `test_an_ordinary_github_repo_is_not_mistaken_for_copilot_and_codex` — builds exactly the repo above and asserts the command exits 1 **and that the existing `AGENTS.md` is byte-for-byte unchanged**. Asserting on the file, not just the exit code, is the point.
- `test_a_github_directory_alone_does_not_imply_copilot`
- `test_add_skills_codex_requires_an_explicit_request` — auto-detect must skip it and leave the file alone; `--agent codex` must still work and preserve existing content.
- `test_every_auto_detected_marker_is_agent_specific` — iterates `_AGENT_MARKERS`, creates one marker at a time, asserts exactly one agent is selected. A structural guard so a future marker can't be a path projects create for other reasons.
- `test_explicitly_requested_agents_still_bypass_detection`

Two existing tests encoded the old behaviour (`auto_detect_copilot` on a bare `.github/`, `auto_detect_codex` on a bare `AGENTS.md`) and were updated — the first to create the real Copilot file, the second to become the explicit-request test.

Three tests fail on `main`.

`make check` green: 257 passed.
