### PR TITLE
fix: generated and scaffolded API servers bind loopback

### DIFF
--- a/changelog.d/73.fixed.md
+++ b/changelog.d/73.fixed.md
@@ -1,0 +1,3 @@
+Generated and scaffolded FastAPI servers now bind `127.0.0.1` instead of `0.0.0.0`.
+`intpot serve --api` already defaulted to loopback, but `eject --to api` and
+`init --type api` produced files that listened on every network interface.

--- a/src/intpot/templates/api_app.py.j2
+++ b/src/intpot/templates/api_app.py.j2
@@ -55,4 +55,6 @@ app = FastAPI()
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+    # Loopback only. Change to "0.0.0.0" to expose this on the network.
+    uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/src/intpot/templates/scaffold/api/main.py
+++ b/src/intpot/templates/scaffold/api/main.py
@@ -14,4 +14,5 @@ def hello(name: str = "world") -> dict:
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    # Loopback only. Change to "0.0.0.0" to expose this on the network.
+    uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/tests/test_commands/test_init.py
+++ b/tests/test_commands/test_init.py
@@ -44,3 +44,15 @@ def test_init_existing_dir(tmp_path, monkeypatch):
     (tmp_path / "existing").mkdir()
     result = runner.invoke(app, ["init", "existing", "--type", "mcp"])
     assert result.exit_code == 1
+
+
+def test_scaffolded_api_binds_loopback_not_every_interface(tmp_path, monkeypatch):
+    """`intpot init --type api` must not scaffold a network-exposed server."""
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["init", "my-api", "--type", "api"])
+
+    assert result.exit_code == 0
+    content = (tmp_path / "my-api" / "main.py").read_text()
+    assert 'host="127.0.0.1"' in content
+    assert 'uvicorn.run(app, host="0.0.0.0"' not in content

--- a/tests/test_generators/test_api_generator.py
+++ b/tests/test_generators/test_api_generator.py
@@ -103,3 +103,47 @@ def test_blank_lines_between_top_level_defs_are_capped():
     code = APIGenerator().generate(tools)
 
     assert "\n\n\n\n" not in code
+
+
+def _one_tool() -> list[ToolInfo]:
+    return [
+        ToolInfo(
+            name="echo",
+            description="Echo.",
+            parameters=[ParameterInfo(name="msg", type_annotation="str")],
+            return_type="dict",
+            function_body='return {"msg": msg}',
+        )
+    ]
+
+
+def test_generated_api_binds_loopback_not_every_interface():
+    """Generated code must not put the user on the network without asking.
+
+    `serve --api` has defaulted to 127.0.0.1 since #60, but the generated file
+    still called uvicorn with host="0.0.0.0" — so ejecting and running it
+    exposed the tools on every interface, which is the opposite of what the
+    docs promise.
+    """
+    output = APIGenerator().generate(_one_tool())
+
+    assert '"127.0.0.1"' in output
+    assert "0.0.0.0" not in output.replace(
+        '# Loopback only. Change to "0.0.0.0" to expose this on the network.', ""
+    )
+
+
+def test_generated_host_matches_the_serve_default():
+    """Whatever `App.serve` defaults to, the generated file must agree.
+
+    They are the same app in two forms; a divergence here is how the last one
+    went unnoticed.
+    """
+    import inspect as _inspect
+
+    from intpot.runtime import App
+
+    serve_default = _inspect.signature(App.serve).parameters["host"].default
+    output = APIGenerator().generate(_one_tool())
+
+    assert f'host="{serve_default}"' in output


### PR DESCRIPTION
Ejecting an API app and running it exposed the user's tools on every network interface, despite `serve` and the documentation both promising loopback.

## The divergence

| | Host |
|---|---|
| `intpot serve --api` | `127.0.0.1` since #60 |
| Shipped skill | *"`serve --api` binds `127.0.0.1`. Pass `--host 0.0.0.0` to expose it on the network."* |
| `templates/api_app.py.j2` | **`0.0.0.0`** |
| `templates/scaffold/api/main.py` | **`0.0.0.0`** |

So `intpot eject --to api` and `intpot init --type api` both produced:

```python
uvicorn.run(app, host="0.0.0.0", port=8000)
```

#60 fixed the runtime default for exactly this reason and the generated code was missed. `serve` and `eject` are the same app in two forms — the AGENTS.md parity rule — and this is the direction where getting it wrong matters.

## Fix

Both templates bind `127.0.0.1`, with a comment naming the one-word change to opt in:

```python
# Loopback only. Change to "0.0.0.0" to expose this on the network.
uvicorn.run(app, host="127.0.0.1", port=8000)
```

## Tests

- `test_generated_api_binds_loopback_not_every_interface` — asserts on the generated source, ignoring the opt-in comment so the comment can't satisfy the check.
- `test_scaffolded_api_binds_loopback_not_every_interface` — runs `intpot init --type api` and reads the scaffolded `main.py`.
- `test_generated_host_matches_the_serve_default` — reads the default off `inspect.signature(App.serve)` and asserts the generated file agrees. This is the one that matters going forward: change `serve`'s default alone and it fails, so the two can't drift apart again.

All three fail on `main`.

`make check` green: 256 passed.
