### PR TITLE
ci: harden workflows and fix the changelog gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+# Keep dependencies up to date.
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+#
+# Workflow actions are pinned to commit SHAs, which nothing else will ever move.
+# Without this file those pins silently rot, security fixes included.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "skip-changelog"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "skip-changelog"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "pytest*"
+          - "ruff"
+          - "pyright"
+          - "pre-commit"
+          - "towncrier"
+      runtime-dependencies:
+        patterns:
+          - "typer"
+          - "jinja2"
+          - "fastapi*"
+          - "fastmcp"
+          - "uvicorn"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,46 @@
+name: Changelog
+
+on:
+  pull_request:
+    branches: [main]
+    # `labeled`/`unlabeled` matter: applying `skip-changelog` has to re-run this
+    # check. Living in ci.yml with the default types, it did not, so a labelled
+    # PR stayed red until someone happened to push again.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read # Required to inspect the pull request's changed files.
+
+concurrency:
+  group: changelog-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  changelog:
+    name: changelog
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Skip non-user-facing changes
+        if: contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+        run: echo "skip-changelog label present"
+      - name: Require this PR's changelog fragment
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Anchored to this PR's own number: a fragment belonging to some other
+          # PR used to satisfy the check.
+          pattern="^changelog\.d/${PR_NUMBER}\.(added|changed|deprecated|removed|fixed)\.md$"
+          if gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --paginate --jq '.[].filename' | grep -Eq "$pattern"; then
+            echo "changelog fragment found for PR #${PR_NUMBER}"
+            exit 0
+          fi
+          echo "::error::no changelog fragment for PR #${PR_NUMBER} — add changelog.d/${PR_NUMBER}.<type>.md (see changelog.d/README.md), or apply the 'skip-changelog' label if this change is not user-facing"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,50 +7,102 @@ on:
     branches: [main]
   workflow_call:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
+    name: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-      - run: uv sync --all-extras
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - run: uv sync --all-extras --locked
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
 
   typecheck:
+    name: typecheck
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-      - run: uv sync --all-extras
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - run: uv sync --all-extras --locked
       - run: uv run pyright src/ tests/
 
-  changelog:
-    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: PR must touch a changelog fragment
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if gh pr diff ${{ github.event.pull_request.number }} --name-only \
-             | grep -Eq '^changelog\.d/[0-9]+\.(added|changed|deprecated|removed|fixed)\.md$'; then
-            echo "changelog fragment found"
-            exit 0
-          fi
-          echo "::error::no changelog fragment in this PR — add changelog.d/${{ github.event.pull_request.number }}.<type>.md (see changelog.d/README.md), or apply the 'skip-changelog' label if this change isn't user-facing"
-          exit 1
-
   test:
+    name: test (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           python-version: ${{ matrix.python-version }}
-      - run: uv sync --all-extras
-      - run: uv run pytest tests/ -v --cov=src/intpot --cov-report=term-missing
+      - run: uv sync --all-extras --locked
+      - run: >-
+          uv run pytest tests/ -v
+          --cov=src/intpot
+          --cov-report=term-missing
+          --cov-fail-under=80
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - run: uv build
+      # Packaging breaks are otherwise only discovered while cutting a release.
+      - name: Verify distribution artifacts
+        run: |
+          python3 - <<'PY'
+          import glob
+          import tarfile
+          import zipfile
+
+          wheels = glob.glob("dist/*.whl")
+          sdists = glob.glob("dist/*.tar.gz")
+          assert len(wheels) == 1, f"expected one wheel, found {wheels}"
+          assert len(sdists) == 1, f"expected one sdist, found {sdists}"
+
+          with zipfile.ZipFile(wheels[0]) as archive:
+              names = archive.namelist()
+              assert "intpot/__init__.py" in names, names
+              # Template data backs three different commands, and a wheel that
+              # drops any of them still imports cleanly — the failure only shows
+              # up when a user runs the command.
+              for required, breaks in [
+                  ("intpot/templates/cli_app.py.j2", "every generator"),
+                  ("intpot/templates/scaffold/", "intpot init"),
+                  ("intpot/templates/skills/", "intpot add skills"),
+              ]:
+                  assert any(n.startswith(required) for n in names), (
+                      f"{required} missing from the wheel — {breaks} would fail"
+                  )
+
+          with tarfile.open(sdists[0]) as archive:
+              names = archive.getnames()
+              assert any(n.endswith("/src/intpot/__init__.py") for n in names), names
+
+          print(f"verified {wheels[0]} and {sdists[0]}")
+          PY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,74 +4,158 @@ on:
   push:
     tags: ["v*"]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false # Never cancel a release midway.
+
 jobs:
   ci:
+    name: CI
     uses: ./.github/workflows/ci.yml
 
   verify-version:
+    name: verify version and changelog
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - name: Tag must match the version in pyproject.toml
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify tag, package version, and changelog
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          tag="${GITHUB_REF_NAME#v}"
-          pkg="$(python3 -c 'import tomllib, pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
-          if [ "$tag" != "$pkg" ]; then
-            echo "::error::tag v$tag does not match pyproject.toml version $pkg — run 'uv version $tag' on main first"
-            exit 1
-          fi
-          echo "tag v$tag matches pyproject.toml version $pkg"
-      - name: CHANGELOG must have a section for this version
-        run: |
-          tag="${GITHUB_REF_NAME#v}"
-          if ! grep -q "^## \[$tag\]" CHANGELOG.md; then
-            echo "::error::CHANGELOG.md has no '## [$tag]' section — promote [Unreleased] before tagging"
-            exit 1
-          fi
-          echo "CHANGELOG.md has a section for $tag"
+          python3 - <<'PY'
+          import os
+          import pathlib
+          import re
+          import sys
+          import tomllib
+
+          tag = os.environ["RELEASE_TAG"]
+          if not tag.startswith("v") or len(tag) == 1:
+              print(f"::error::release tag must be v<version>, got {tag!r}")
+              sys.exit(1)
+
+          version = tag[1:]
+          package_version = tomllib.loads(
+              pathlib.Path("pyproject.toml").read_text()
+          )["project"]["version"]
+          if version != package_version:
+              print(
+                  f"::error::tag {tag} does not match pyproject.toml version "
+                  f"{package_version} — run 'uv version {version}' on main first"
+              )
+              sys.exit(1)
+
+          changelog = pathlib.Path("CHANGELOG.md").read_text()
+          heading = re.compile(rf"^## \[{re.escape(version)}\](?:\s|$)", re.MULTILINE)
+          if heading.search(changelog) is None:
+              print(
+                  f"::error::CHANGELOG.md has no exact '## [{version}]' section — "
+                  "run 'make changelog' and commit it before tagging"
+              )
+              sys.exit(1)
+
+          print(f"{tag} matches pyproject.toml and CHANGELOG.md")
+          PY
 
   build:
+    name: build release artifacts
     needs: [ci, verify-version]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: false # Build the artifact that ships from a clean slate.
       - run: uv build
-      - uses: actions/upload-artifact@v4
+      - name: Verify release artifacts
+        run: |
+          python3 - <<'PY'
+          import glob
+          import tarfile
+          import zipfile
+
+          wheels = glob.glob("dist/*.whl")
+          sdists = glob.glob("dist/*.tar.gz")
+          assert len(wheels) == 1, f"expected one wheel, found {wheels}"
+          assert len(sdists) == 1, f"expected one sdist, found {sdists}"
+
+          with zipfile.ZipFile(wheels[0]) as archive:
+              names = archive.namelist()
+              assert "intpot/__init__.py" in names, names
+              for required in [
+                  "intpot/templates/cli_app.py.j2",
+                  "intpot/templates/scaffold/",
+                  "intpot/templates/skills/",
+              ]:
+                  assert any(n.startswith(required) for n in names), (
+                      f"{required} missing from the wheel"
+                  )
+
+          with tarfile.open(sdists[0]) as archive:
+              names = archive.getnames()
+              assert any(n.endswith("/src/intpot/__init__.py") for n in names), names
+
+          print(f"verified {wheels[0]} and {sdists[0]}")
+          PY
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
+          if-no-files-found: error
 
   publish:
+    name: publish to PyPI
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: pypi
     permissions:
-      id-token: write
+      contents: read
+      id-token: write # Required for PyPI trusted publishing via OIDC.
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          attestations: true # Publish PEP 740 provenance alongside the files.
 
   github-release:
+    name: create GitHub Release
     needs: publish
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
-      contents: write
+      contents: write # Required to create the GitHub Release and upload assets.
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
       - name: Extract release notes from CHANGELOG
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
         run: |
-          python3 - "${GITHUB_REF_NAME#v}" > release-notes.md <<'PY'
-          import pathlib, re, sys
+          python3 - <<'PY' > release-notes.md
+          import os
+          import pathlib
+          import re
+          import sys
 
-          version = sys.argv[1]
+          version = os.environ["RELEASE_VERSION"].removeprefix("v")
           text = pathlib.Path("CHANGELOG.md").read_text()
           match = re.search(
               rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## \[|\Z)",
@@ -79,20 +163,22 @@ jobs:
               re.MULTILINE | re.DOTALL,
           )
           if match is None:
-              sys.exit(f"no '## [{version}]' section in CHANGELOG.md")
+              sys.exit(f"no exact '## [{version}]' section in CHANGELOG.md")
           print(match.group(1).strip())
           PY
           cat release-notes.md
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          version="${GITHUB_REF_NAME#v}"
-          prerelease=""
-          case "$version" in *-*) prerelease="--prerelease" ;; esac
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          args=()
+          case "$version" in *-*) args+=(--prerelease) ;; esac
+          gh release create "$RELEASE_TAG" \
+            --title "$RELEASE_TAG" \
             --notes-file release-notes.md \
             --verify-tag \
-            $prerelease \
+            "${args[@]}" \
             dist/*


### PR DESCRIPTION
Borrowed from `summonpot`, whose workflows are a generation ahead of this repo's.

## The correctness fix

`uv sync --all-extras` → `uv sync --all-extras --locked`.

Without `--locked`, CI is free to resolve dependencies differently from `uv.lock`. A green run therefore didn't prove that the lockfile a user installs from actually works. This is the single most valuable line in the diff.

## The changelog gate was broken in two ways

It moves out of `ci.yml` into its own workflow.

1. **Labelling didn't re-run it.** `ci.yml` uses `pull_request` with the default types (`opened`, `synchronize`, `reopened`), so applying `skip-changelog` did nothing and the PR stayed red until someone happened to push. #69 hit exactly this. The new workflow adds `labeled, unlabeled`.
2. **It accepted any fragment.** The pattern was `^changelog\.d/[0-9]+\.…`, so a PR touching some *other* PR's fragment passed. It's now anchored to `${PR_NUMBER}`.

It also uses `gh api --paginate` rather than `gh pr diff --name-only`, which doesn't truncate on large PRs, and runs under `set -euo pipefail`.

## Hardening

None of this existed here:

| | Before | After |
|---|---|---|
| `permissions:` | unset (default token scope) | `contents: read` at both roots, widened per job with a comment explaining why |
| `concurrency` | none — superseded runs kept running | cancel-in-progress on CI; explicitly **off** for releases |
| `timeout-minutes` | none — hung jobs run 6 hours | 5–15 per job |
| Action pinning | `@v4` / `@v5` — tags can be moved | 40-char SHAs, version in a comment |
| Action versions | checkout v4, setup-uv v5 | checkout v7.0.1, setup-uv v9.0.0 |
| `persist-credentials` | default `true` | `false` |

Every SHA was verified against its tag through the GitHub API before pinning.

## CI now builds

Packaging breaks were previously found while cutting a release. The new `build` job asserts the wheel carries **all three** template families, because a wheel missing one still imports cleanly and only fails when a user runs the command that reads it:

- `templates/*.j2` → every generator
- `templates/scaffold/` → `intpot init`
- `templates/skills/` → `intpot add skills`

Given #67 shipped a broken `add skills`, that last one is worth asserting.

Releases additionally verify artifacts before publishing, upload with `if-no-files-found: error`, publish PEP 740 attestations, build with the uv cache disabled, and validate the tag format instead of assuming a `v` prefix.

## Coverage gate

`--cov-fail-under=80`. Coverage is currently 87.74%, so this is a floor rather than a target — easy to raise later.

## dependabot.yml

Required, not optional: SHA pins are invisible to every other update mechanism, so without this they rot silently, security fixes included. Runtime and dev dependencies are grouped so updates arrive as two PRs rather than a dozen. Both label sets include `skip-changelog` so dependency bumps don't trip the gate. (The `dependencies` label didn't exist in this repo and has been created — Dependabot cannot create labels itself.)

## Deliberately not taken

**`stale.yml`.** It marks issues stale after 60 days and closes them 14 days later, exempting only `enhancement,pinned,security`. This repo's ~20 open issues exist specifically to attract contributors; auto-closing them works directly against that.

**`labeler.yml`.** Needs a path-to-label config and adds `pull_request_target` (a write-scoped token on fork PRs) for little benefit while you're the only one merging.

## Verification

Locally: all four YAML files parse; `uv sync --all-extras --locked` succeeds against the current lockfile; the wheel-verification script was **extracted from the workflow YAML and executed verbatim** rather than retyped, and passes; coverage clears the new gate at 87.74%.

This PR is intentionally opened **without** the `skip-changelog` label so the changelog job can be observed failing and then going green on the label alone, with no push — the behaviour it exists to fix.
