### PR TITLE
fix: extract Typer apps again on typer 0.27

### DIFF
--- a/changelog.d/77.fixed.md
+++ b/changelog.d/77.fixed.md
@@ -1,0 +1,4 @@
+Typer apps are readable again on typer 0.27, which vendors its own copy of click. Every
+`isinstance` and identity check against the standalone `click` package stopped matching,
+so `intpot inspect`, `to mcp`, `to api` and `to cli` found no tools at all in any Typer
+source, and would have typed every parameter `str` had they found them.

--- a/src/intpot/core/inspectors/cli.py
+++ b/src/intpot/core/inspectors/cli.py
@@ -12,7 +12,7 @@ from intpot.core.models import _SENTINEL, ParameterInfo, ToolInfo
 # Typer vendors its own copy of click (`typer._click`), so a Typer app's objects
 # are not instances of anything in the standalone `click` package and its
 # parameter types are not click's singletons. Everything here is therefore
-# matched structurally rather than by identity or isinstance.
+# matched structurally rather than by identity or isinstance — see #77.
 _PARAM_TYPE_NAMES = {
     # click's own vocabulary
     "text": "str",

--- a/src/intpot/core/inspectors/cli.py
+++ b/src/intpot/core/inspectors/cli.py
@@ -5,25 +5,42 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-import click
-
 from intpot.core.inspectors._utils import extract_function_body, extract_source_imports
 from intpot.core.inspectors.base import BaseInspector
 from intpot.core.models import _SENTINEL, ParameterInfo, ToolInfo
 
+# Typer vendors its own copy of click (`typer._click`), so a Typer app's objects
+# are not instances of anything in the standalone `click` package and its
+# parameter types are not click's singletons. Everything here is therefore
+# matched structurally rather than by identity or isinstance.
+_PARAM_TYPE_NAMES = {
+    # click's own vocabulary
+    "text": "str",
+    "integer": "int",
+    "float": "float",
+    "boolean": "bool",
+    # typer's vendored click reports Python names directly
+    "str": "str",
+    "int": "int",
+    "bool": "bool",
+    "string": "str",
+}
+
 
 def _click_type_to_str(param_type: Any) -> str:
-    """Map Click parameter types to Python type name strings."""
-    type_map = {
-        click.STRING: "str",
-        click.INT: "int",
-        click.FLOAT: "float",
-        click.BOOL: "bool",
-    }
-    for click_type, name in type_map.items():
-        if param_type is click_type or isinstance(param_type, type(click_type)):
-            return name
-    return "str"
+    """Map a Click/Typer parameter type to a Python type name."""
+    name = getattr(param_type, "name", None)
+    if isinstance(name, str) and name.lower() in _PARAM_TYPE_NAMES:
+        return _PARAM_TYPE_NAMES[name.lower()]
+    # Fall back to the class name: IntParamType -> "int".
+    cls_name = type(param_type).__name__.removesuffix("ParamType").lower()
+    return _PARAM_TYPE_NAMES.get(cls_name, "str")
+
+
+def _child_commands(obj: Any) -> dict[str, Any] | None:
+    """The sub-commands of a group, or None if this is a leaf command."""
+    commands = getattr(obj, "commands", None)
+    return commands if isinstance(commands, dict) else None
 
 
 class CLIInspector(BaseInspector):
@@ -53,16 +70,15 @@ class CLIInspector(BaseInspector):
 
     def _extract_commands(
         self,
-        group: click.BaseCommand,  # type: ignore[reportGeneralTypeIssues]
+        group: Any,
         tools: list[ToolInfo],
         prefix: str = "",
     ) -> None:
-        """Recursively extract commands from Click groups."""
-        commands: dict[str, click.Command] = {}
-        if isinstance(group, click.Group):
-            commands = group.commands
-        elif isinstance(group, click.Command):
-            commands = {group.name or "main": group}
+        """Recursively extract commands from Click/Typer groups."""
+        commands = _child_commands(group)
+        if commands is None:
+            # A single command rather than a group.
+            commands = {getattr(group, "name", None) or "main": group}
 
         for cmd_name, cmd in commands.items():
             if cmd_name is None:
@@ -71,7 +87,7 @@ class CLIInspector(BaseInspector):
             full_name = f"{prefix}{cmd_name}".replace("-", "_")
 
             # Recurse into sub-groups
-            if isinstance(cmd, click.Group):
+            if _child_commands(cmd) is not None:
                 self._extract_commands(cmd, tools, prefix=f"{full_name}_")
                 continue
 
@@ -79,7 +95,7 @@ class CLIInspector(BaseInspector):
 
     def _extract_single_command(
         self,
-        cmd: click.Command,
+        cmd: Any,
         name: str,
         tools: list[ToolInfo],
     ) -> None:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -12,8 +12,8 @@ import re
 import subprocess
 from fnmatch import fnmatch
 from pathlib import Path
+from typing import Any
 
-import click
 import pytest
 from typer.main import get_command
 
@@ -29,17 +29,51 @@ def _cli_flags() -> list[tuple[str, str]]:
     """Every long option the CLI exposes, as (command path, flag)."""
     found: list[tuple[str, str]] = []
 
-    def walk(command: click.Command, path: list[str]) -> None:
+    def walk(command: Any, path: list[str]) -> None:
         for param in command.params:
             for opt in getattr(param, "opts", []):
                 if opt.startswith("--") and opt not in _GENERATED_FLAGS:
                     found.append((" ".join(path), opt))
-        if isinstance(command, click.Group):
-            for name, sub in command.commands.items():
+        # Duck-typed: typer vendors its own click, so `isinstance(command,
+        # click.Group)` matches nothing and this walk silently stopped
+        # descending into subcommands. See test_cli_flag_discovery_is_not_vacuous.
+        children = getattr(command, "commands", None)
+        if isinstance(children, dict):
+            for name, sub in children.items():
                 walk(sub, [*path, name])
 
     walk(get_command(app), ["intpot"])
     return sorted(set(found))
+
+
+# Every command that exposes at least one long flag. Hard-coded on purpose:
+# deriving it from the same walk being tested would make the check circular.
+_COMMANDS_WITH_FLAGS = [
+    "intpot serve",
+    "intpot inspect",
+    "intpot eject",
+    "intpot init",
+    "intpot to cli",
+    "intpot to mcp",
+    "intpot to api",
+    "intpot add skills",
+]
+
+
+def test_cli_flag_discovery_is_not_vacuous():
+    """A parametrised test that collects nothing still reports green.
+
+    The walk above used to gate on `isinstance(command, click.Group)`. typer
+    0.27 vendors click, so that matched nothing, the walk never descended, and
+    this file quietly went from 22 flag assertions to 1 — with the whole suite
+    still passing. A silently empty guard is worse than no guard.
+    """
+    flags = _cli_flags()
+    discovered = {command for command, _ in flags}
+
+    assert len(flags) >= 15, f"only {len(flags)} flags discovered: {flags}"
+    missing = [c for c in _COMMANDS_WITH_FLAGS if c not in discovered]
+    assert not missing, f"not discovered: {missing} (found {sorted(discovered)})"
 
 
 @pytest.mark.parametrize(("command", "flag"), _cli_flags())

--- a/tests/test_inspectors/test_cli_inspector.py
+++ b/tests/test_inspectors/test_cli_inspector.py
@@ -50,3 +50,100 @@ def test_inspect_empty_typer():
     inspector = CLIInspector()
     tools = inspector.inspect(app)
     assert tools == []
+
+
+# ---------------------------------------------------------------------------
+# Vendored-click compatibility
+#
+# Typer 0.27 ships its own copy of click as `typer._click`, so a Typer app's
+# objects are not instances of anything in the standalone `click` package.
+# Every isinstance/identity check against click silently stopped matching:
+# `intpot inspect` reported "No tools found" for every Typer app, and had the
+# groups been found, every parameter would have been typed `str`.
+#
+# These stubs inherit from nothing, so they reproduce that on any installed
+# typer version rather than only on the one CI happens to pin.
+# ---------------------------------------------------------------------------
+
+
+class _StubType:
+    """Stands in for a vendored click ParamType."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _StubParam:
+    def __init__(self, name, type_name, required=True, default=None, help_=""):
+        self.name = name
+        self.type = _StubType(type_name)
+        self.required = required
+        self.default = default
+        self.help = help_
+
+
+class _StubCommand:
+    def __init__(self, name, params=None, help_=""):
+        self.name = name
+        self.params = params or []
+        self.help = help_
+        self.callback = None
+
+
+class _StubGroup:
+    def __init__(self, commands):
+        self.name = "root"
+        self.commands = commands
+
+
+def test_a_group_that_is_not_a_click_subclass_is_still_walked():
+    group = _StubGroup({"greet": _StubCommand("greet", help_="Greet someone.")})
+
+    tools = CLIInspector().inspect(group)
+
+    assert [t.name for t in tools] == ["greet"]
+    assert tools[0].description == "Greet someone."
+
+
+def test_nested_groups_that_are_not_click_subclasses_are_walked():
+    inner = _StubGroup({"child": _StubCommand("child")})
+    outer = _StubGroup({"parent": inner})
+
+    tools = CLIInspector().inspect(outer)
+
+    assert [t.name for t in tools] == ["parent_child"]
+
+
+def test_parameter_types_are_matched_structurally_not_by_identity():
+    """Both vocabularies must map: click says 'integer', typer says 'int'."""
+    command = _StubCommand(
+        "calc",
+        params=[
+            _StubParam("a", "int"),  # typer's vendored click
+            _StubParam("b", "integer"),  # click's own
+            _StubParam("c", "float"),
+            _StubParam("d", "boolean"),
+            _StubParam("e", "text"),  # click's name for str
+            _StubParam("f", "str"),
+        ],
+    )
+
+    tools = CLIInspector().inspect(_StubGroup({"calc": command}))
+    types = {p.name: p.type_annotation for p in tools[0].parameters}
+
+    assert types == {
+        "a": "int",
+        "b": "int",
+        "c": "float",
+        "d": "bool",
+        "e": "str",
+        "f": "str",
+    }
+
+
+def test_an_unrecognised_parameter_type_falls_back_to_str():
+    command = _StubCommand("pick", params=[_StubParam("choice", "choice")])
+
+    tools = CLIInspector().inspect(_StubGroup({"pick": command}))
+
+    assert tools[0].parameters[0].type_annotation == "str"


### PR DESCRIPTION
**intpot 0.5.0 on PyPI cannot read any Typer app on a current install.** `pyproject.toml` declares `typer>=0.9.0` with no upper bound, so a fresh `pip install intpot` today resolves typer 0.27 — and half of what intpot does silently stops working.

Not from the consolidated review: that ran against `uv.lock`, which pins typer 0.24.1. Only the Dependabot bump in #76 exposed it, one day after `dependabot.yml` landed in #74.

## Cause

typer 0.27 vendors its own copy of click as `typer._click`:

```
get_group(app)               -> typer.core.TyperGroup
isinstance(_, click.Group)   -> False
TyperGroup.__mro__           -> (TyperGroup, typer._click.core.Command, ABC, object)
```

A Typer app's objects are not instances of anything in the standalone `click` package. Every check in this inspector was written against click, so they all stopped matching simultaneously:

| Check | Consequence |
|---|---|
| `isinstance(group, click.Group)` in `_extract_commands` | `commands` stays `{}` → **zero tools**, no error, "No tools found" |
| `param_type is click.INT` / `isinstance(..., type(click.INT))` | a Typer param is `typer._click.types.IntParamType` → **every parameter typed `str`** |

The second was masked by the first — nothing got far enough to mistype a parameter.

## Fix

Match structurally, which is what `detector.py` and `_is_depends` already do in this codebase, for exactly this reason:

- **Sub-commands** — presence of a `commands` mapping, via `_child_commands()`. Also drives the recursion into nested groups.
- **Parameter types** — the type's own `name`, accepting click's vocabulary (`integer`, `text`) and typer's (`int`, `str`), falling back to the class name (`IntParamType` → `int`) and finally to `str`.

`import click` is gone from the module entirely. The `click.BaseCommand` annotation went with it — that name is deprecated and slated for removal in click 9.

## Verification

Run with the source on `PYTHONPATH` against each version:

| | typer 0.24.1 (locked) | typer 0.27.1 |
|---|---|---|
| before | 1 tool, types correct | **0 tools** |
| after | 1 tool, types correct | 1 tool, `int`/`float`/`bool`/`str` correct |

## Tests

The stubs inherit from nothing, so they reproduce the vendored-click situation on **whatever typer version happens to be installed** — otherwise the regression is invisible until the lockfile moves.

- `test_a_group_that_is_not_a_click_subclass_is_still_walked`
- `test_nested_groups_that_are_not_click_subclasses_are_walked`
- `test_parameter_types_are_matched_structurally_not_by_identity` — both vocabularies in one table
- `test_an_unrecognised_parameter_type_falls_back_to_str` — guards the fallback, so `Choice` doesn't become something wrong

All four fail on `main`. `make check` green: 274 passed.

## Follow-on

This should turn #76 green. Once it is, intpot needs a **0.5.1 released promptly** — the published version is broken for Typer input for anyone installing fresh.


---

## Second commit: the README guard had the same bug and had gone silent

While verifying this branch against #76's dependency set, the suite dropped from **274 tests to 253 with no failure**. The 21 missing tests were parametrised cases of `test_readme_documents_every_cli_flag`.

`tests/test_docs.py` walks the command tree with the identical construct:

```python
if isinstance(command, click.Group):
    for name, sub in command.commands.items():
```

Under typer 0.27 that matches nothing, the walk never descends, and `_cli_flags()` returns one entry — `intpot --version` — instead of 22. The README guard added in #69 quietly stopped checking anything, and the suite stayed green.

That is the worst failure mode a test has: not red, just absent.

Fixed the same way, plus `test_cli_flag_discovery_is_not_vacuous`, which asserts a floor on discovery and names the commands that must be found. The expected list is hard-coded rather than derived from the walk under test, which would be circular.

**275 tests pass under both typer 0.24.1 and 0.27.1**, verified by running the suite twice against pinned versions.
