### PR TITLE
chore: keep ruff away from the Markdown skills

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ reportAssignmentType = false
 [tool.ruff]
 target-version = "py311"
 line-length = 88
+# ruff 0.16 formats Python code blocks inside Markdown. The skills under
+# templates/skills/ are documentation shipped to users, and their examples use
+# deliberate comment alignment that reads better than the formatter's output.
+# Their content is guarded by tests/test_skills_content.py, not by the formatter.
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]


### PR DESCRIPTION
The ruff 0.15.4 → 0.16.2 bump in #75 fails `lint`. This is why, and it isn't a code problem.

ruff 0.16 formats Python code blocks **inside Markdown files**, so `ruff format src/ tests/` began rewriting `src/intpot/templates/skills/*.md`:

```diff
-app.serve(mode="cli")                     # run as a Typer CLI
-app.serve(mode="api", port=8000)          # FastAPI on 127.0.0.1 by default
-app.serve(mode="api", host="0.0.0.0")     # opt in to network exposure
+app.serve(mode="cli")  # run as a Typer CLI
+app.serve(mode="api", port=8000)  # FastAPI on 127.0.0.1 by default
+app.serve(mode="api", host="0.0.0.0")  # opt in to network exposure
```

Those files are documentation shipped into users' projects by `intpot add skills`, and the aligned comments are what make the examples scannable. The formatter's output is correct Python and worse prose.

`extend-exclude = ["*.md"]` — the repo has no Markdown it wants linted or formatted, and skill *content* is already guarded by `tests/test_skills_content.py`, which is the check that actually matters for those files.

## Verification

| | result |
|---|---|
| ruff 0.16.2 `format --check` | 69 files already formatted |
| ruff 0.16.2 `check` | All checks passed |
| pinned ruff 0.15.4, `make check` | 270 passed |

Both versions are satisfied, so this can merge before or after #75.

After it lands, `@dependabot rebase` on #75 should turn it green.
