### PR TITLE
fix: generated code parses whatever the source app contains

### DIFF
--- a/changelog.d/79.fixed.md
+++ b/changelog.d/79.fixed.md
@@ -1,0 +1,6 @@
+Generated code now parses regardless of what the source app contains. A parameter
+description holding a quote, newline or backslash produced an unterminated string literal
+from `to cli` and `to api`; two parameters whose names sanitised onto the same identifier
+produced a duplicate argument; non-ASCII names like `café` were mangled to `caf_`; and
+`intpot init` accepted project names containing quotes, scaffolding a project that would
+not parse.

--- a/src/intpot/commands/init.py
+++ b/src/intpot/commands/init.py
@@ -27,6 +27,18 @@ def init_command(
         typer.echo("Project name must not contain path separators.", err=True)
         raise typer.Exit(1)
 
+    # The name is substituted into a docstring and a string literal in the
+    # scaffolded source, so a quote, newline or control character produced a
+    # project that would not even parse.
+    invalid = {ch for ch in name if ch in "'\"" or ord(ch) < 32}
+    if invalid:
+        shown = ", ".join(repr(ch) for ch in sorted(invalid))
+        typer.echo(
+            f"Project name must not contain quotes or control characters: {shown}",
+            err=True,
+        )
+        raise typer.Exit(1)
+
     target_dir = Path.cwd() / name
     if target_dir.exists():
         typer.echo(f"Directory '{name}' already exists.", err=True)

--- a/src/intpot/core/generators/_render.py
+++ b/src/intpot/core/generators/_render.py
@@ -61,8 +61,22 @@ def _to_pascal_case(name: str) -> str:
 
 
 def _escape_docstring(text: str) -> str:
-    """Escape triple quotes in docstrings to prevent syntax errors."""
-    return text.replace('"""', '\\"\\"\\"')
+    """Make text safe to drop between triple quotes.
+
+    Backslashes are escaped first, or escaping the quotes would re-introduce
+    them. Text ending in a double quote is escaped too, otherwise it runs into
+    the closing delimiter and starts a fourth quote.
+
+    This is only for docstrings. Where a string *literal* is needed, use the
+    `repr` filter instead: hand-written quotes around arbitrary text produced
+    'SyntaxError: unterminated string literal' for any description containing a
+    quote or a newline.
+    """
+    text = text.replace("\\", "\\\\")
+    text = text.replace('"""', '\\"\\"\\"')
+    if text.endswith('"'):
+        text = text[:-1] + '\\"'
+    return text
 
 
 _FRAMEWORK_IMPORT_MARKERS = {

--- a/src/intpot/core/models.py
+++ b/src/intpot/core/models.py
@@ -64,8 +64,13 @@ def sanitize_identifier(name: str) -> str:
     """
     if not name or not name.strip():
         return "_"
-    # Replace any character that is not alphanumeric or underscore
-    name = re.sub(r"[^0-9a-zA-Z_]", "_", name)
+    # Replace any character Python would not accept inside an identifier.
+    # Tested per character rather than against [0-9a-zA-Z_]: Python 3 allows
+    # non-ASCII letters, and mangling `café` into `caf_` both lost information
+    # and invented collisions with a genuine `caf_`. `("a" + ch)` is what makes
+    # this exact — it accepts `é` while still rejecting `²`, which is
+    # alphanumeric but not valid in an identifier.
+    name = "".join(ch if ("a" + ch).isidentifier() else "_" for ch in name)
     # Collapse consecutive underscores
     name = re.sub(r"_+", "_", name)
     if not name:
@@ -112,6 +117,27 @@ class ParameterInfo:
         return self.default is _SENTINEL
 
 
+def deduplicate_identifiers(names: list[str]) -> list[str]:
+    """Make a list of identifiers unique, preserving order and first occurrence.
+
+    Sanitising is per-name, so distinct inputs can land on the same identifier:
+    `a-b` and `a_b` both become `a_b`. Two parameters sharing a name is
+    `SyntaxError: duplicate argument` in the generated function, so later
+    collisions get a numeric suffix.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for name in names:
+        candidate = name
+        counter = 2
+        while candidate in seen:
+            candidate = f"{name}_{counter}"
+            counter += 1
+        seen.add(candidate)
+        result.append(candidate)
+    return result
+
+
 @dataclass
 class ToolInfo:
     name: str
@@ -127,3 +153,8 @@ class ToolInfo:
 
     def __post_init__(self) -> None:
         self.name = sanitize_identifier(self.name)
+        # Parameter names are sanitised individually, so two distinct source
+        # names can arrive here already collapsed onto one identifier.
+        unique = deduplicate_identifiers([p.name for p in self.parameters])
+        for param, name in zip(self.parameters, unique, strict=True):
+            param.name = name

--- a/src/intpot/templates/api_app.py.j2
+++ b/src/intpot/templates/api_app.py.j2
@@ -35,8 +35,8 @@ app = FastAPI()
 {%- for param in tool.parameters %}
     {{ param.name }}: {{ param.type_annotation }}
 {%- set fa_type = param.param_source.fastapi_class if param.param_source else "Body" %}
-{%- if not param.required %} = {{ fa_type }}(default={{ param.default | repr }}{% if param.description %}, description="{{ param.description | escape_doc }}"{% endif %})
-{%- else %} = {{ fa_type }}(...{% if param.description %}, description="{{ param.description | escape_doc }}"{% endif %})
+{%- if not param.required %} = {{ fa_type }}(default={{ param.default | repr }}{% if param.description %}, description={{ param.description | repr }}{% endif %})
+{%- else %} = {{ fa_type }}(...{% if param.description %}, description={{ param.description | repr }}{% endif %})
 {%- endif %},
 {%- endfor %}
 {% endif -%}

--- a/src/intpot/templates/cli_app.py.j2
+++ b/src/intpot/templates/cli_app.py.j2
@@ -34,8 +34,8 @@ app = typer.Typer()
 def {{ tool.name }}(
 {%- for param in tool.parameters %}
     {{ param.name }}: {{ param.type_annotation }}
-{%- if not param.required %} = typer.Option({{ param.default | repr }}, help="{{ param.description | escape_doc }}")
-{%- else %} = typer.Argument(..., help="{{ param.description | escape_doc }}")
+{%- if not param.required %} = typer.Option({{ param.default | repr }}, help={{ param.description | repr }})
+{%- else %} = typer.Argument(..., help={{ param.description | repr }})
 {%- endif %},
 {%- endfor %}
 ) -> None:

--- a/tests/test_generated_code_is_valid.py
+++ b/tests/test_generated_code_is_valid.py
@@ -1,0 +1,171 @@
+"""Generated code must parse, whatever the source app contains.
+
+Descriptions, parameter names and project names all come from someone else's
+code. Each of these produced a file that would not compile, and every existing
+test passed because they assert on the generated *string* rather than compiling
+it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from intpot.cli import app as cli_app
+from intpot.core.generators.api import APIGenerator
+from intpot.core.generators.cli import CLIGenerator
+from intpot.core.generators.mcp import MCPGenerator
+from intpot.core.models import (
+    ParameterInfo,
+    ToolInfo,
+    deduplicate_identifiers,
+    sanitize_identifier,
+)
+
+_GENERATORS = [
+    pytest.param(CLIGenerator, id="cli"),
+    pytest.param(APIGenerator, id="api"),
+    pytest.param(MCPGenerator, id="mcp"),
+]
+
+# Each of these, dropped into a hand-quoted string literal, ends the literal
+# early or changes its meaning.
+_HOSTILE_TEXT = [
+    pytest.param('He said "hi"', id="double-quote"),
+    pytest.param("It's fine", id="single-quote"),
+    pytest.param("line one\nline two", id="newline"),
+    pytest.param("a backslash \\ here", id="backslash"),
+    pytest.param('ends with a quote "', id="trailing-quote"),
+    pytest.param('a """ triple quote', id="triple-quote"),
+    pytest.param("tab\tseparated", id="tab"),
+    pytest.param("unicode — em dash, café", id="unicode"),
+]
+
+
+def _tool(description: str = "", param_description: str = "") -> ToolInfo:
+    return ToolInfo(
+        name="demo",
+        description=description,
+        parameters=[
+            ParameterInfo(
+                name="x", type_annotation="str", description=param_description
+            )
+        ],
+        return_type="dict",
+        function_body="return {'x': x}",
+    )
+
+
+@pytest.mark.parametrize("generator", _GENERATORS)
+@pytest.mark.parametrize("text", _HOSTILE_TEXT)
+def test_a_hostile_description_still_compiles(generator, text: str) -> None:
+    source = generator().generate([_tool(description=text)])
+
+    compile(source, "<generated>", "exec")
+
+
+@pytest.mark.parametrize("generator", _GENERATORS)
+@pytest.mark.parametrize("text", _HOSTILE_TEXT)
+def test_a_hostile_parameter_description_still_compiles(generator, text: str) -> None:
+    source = generator().generate([_tool(param_description=text)])
+
+    compile(source, "<generated>", "exec")
+
+
+@pytest.mark.parametrize("generator", _GENERATORS)
+def test_the_description_survives_into_the_generated_module(generator) -> None:
+    """Escaping must not silently mangle the text it protects."""
+    text = 'He said "hi" and left'
+    source = generator().generate([_tool(description=text, param_description=text)])
+
+    namespace: dict[str, object] = {}
+    exec(compile(source, "<generated>", "exec"), namespace)
+
+    assert 'He said "hi" and left' in source
+
+
+# ---------------------------------------------------------------------------
+# Identifier collisions
+# ---------------------------------------------------------------------------
+
+
+def test_parameters_that_sanitise_onto_one_name_are_made_unique() -> None:
+    """`a-b` and `a_b` both sanitise to `a_b` — a duplicate function argument."""
+    tool = ToolInfo(
+        name="f",
+        parameters=[
+            ParameterInfo(name="a-b"),
+            ParameterInfo(name="a_b"),
+            ParameterInfo(name="a.b"),
+        ],
+        function_body="return a_b",
+    )
+
+    assert [p.name for p in tool.parameters] == ["a_b", "a_b_2", "a_b_3"]
+
+
+@pytest.mark.parametrize("generator", _GENERATORS)
+def test_colliding_parameter_names_still_compile(generator) -> None:
+    tool = ToolInfo(
+        name="f",
+        parameters=[ParameterInfo(name="a-b"), ParameterInfo(name="a_b")],
+        return_type="dict",
+        function_body="return {}",
+    )
+
+    compile(generator().generate([tool]), "<generated>", "exec")
+
+
+def test_deduplicate_skips_over_a_name_that_is_already_taken() -> None:
+    assert deduplicate_identifiers(["a", "a", "a_2", "a"]) == [
+        "a",
+        "a_2",
+        "a_2_2",
+        "a_3",
+    ]
+
+
+def test_a_valid_unicode_identifier_is_left_alone() -> None:
+    """Python 3 allows them, and mangling invented collisions."""
+    assert sanitize_identifier("café") == "café"
+    assert sanitize_identifier("δelta") == "δelta"
+
+
+def test_sanitising_still_handles_the_cases_it_always_did() -> None:
+    assert sanitize_identifier("class") == "class_"
+    assert sanitize_identifier("my-tool.v2") == "my_tool_v2"
+    assert sanitize_identifier("123fn") == "_123fn"
+    assert sanitize_identifier("---") == "_"
+    assert sanitize_identifier("") == "_"
+
+
+# ---------------------------------------------------------------------------
+# Scaffolding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ['my"app', "my'app", "app\nname"])
+def test_init_rejects_names_that_would_break_the_scaffold(
+    name: str, tmp_path, monkeypatch
+) -> None:
+    """The name lands in a docstring and a string literal in the generated file."""
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli_app, ["init", name, "--type", "mcp"])
+
+    assert result.exit_code == 1
+    assert "quotes or control characters" in result.output
+    assert not any(tmp_path.iterdir())
+
+
+@pytest.mark.parametrize("project_type", ["mcp", "cli", "api"])
+def test_scaffolded_projects_compile(project_type: str, tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli_app, ["init", "good-name", "--type", project_type])
+
+    assert result.exit_code == 0, result.output
+    written = list((tmp_path / "good-name").glob("*.py"))
+    assert written, "scaffold produced no Python files"
+    for path in written:
+        compile(path.read_text(), str(path), "exec")


### PR DESCRIPTION
Consolidated review items **1**, **6** and **16**. All three reproduced first; all three are ways that someone else's code makes intpot emit a file that will not compile.

Every existing test passed throughout, because they assert on the generated **string** rather than compiling it — the same reason the six bugs in #52–#61 shipped.

## 1. Descriptions were dropped into hand-written quotes

```jinja
help="{{ param.description | escape_doc }}"
```

…and `escape_doc` only replaced `"""`. Reproduced with `He said "hi"\nand a backslash \ here`:

| generator | before |
|---|---|
| `to cli` | `SyntaxError: unterminated string literal` |
| `to api` | `SyntaxError: unterminated string literal` |
| `to mcp` | compiled (descriptions only reach docstrings there) |

Both now use the `repr` filter — Python's own literal-writing routine, correct by construction for quotes, newlines, backslashes and unicode alike.

`escape_doc` stays for docstrings and was itself wrong in two ways, now fixed: backslashes have to be escaped *before* the quotes, and text ending in `"` runs into the closing delimiter.

*(Writing that function's docstring, I put a literal `"""` in it and broke the module — the bug reproducing itself while being fixed.)*

## 6. Identifier collisions

Two separate problems.

**Unicode was mangled.** `sanitize_identifier` mapped everything outside `[0-9a-zA-Z_]` to `_`, so `café` → `caf_`, losing information *and* colliding with a real `caf_`. Characters are now tested individually with `("a" + ch).isidentifier()`, which is exact: it keeps `é` and still rejects `²`, which is alphanumeric but not valid in an identifier.

**Distinct names could collapse onto one.** `a-b` and `a_b` both sanitise to `a_b` — `SyntaxError: duplicate argument 'a_b' in function definition`. `ToolInfo.__post_init__` now runs its parameters through `deduplicate_identifiers`, which suffixes later collisions and skips names already taken (`["a", "a", "a_2", "a"]` → `["a", "a_2", "a_2_2", "a_3"]`).

Existing behaviour is deliberately preserved: `__init__` still collapses to `_init_` (#60), `my-tool.v2` → `my_tool_v2`, `---` → `_`, keywords still get a suffix. My first attempt short-circuited on `str.isidentifier()` and broke the `__init__` case — caught by the existing suite.

## 16. Scaffold names

`intpot init 'my"app'` wrote a project that would not parse:

```python
"""my"app - FastMCP server."""
mcp = FastMCP("my"app")
```

Quotes and control characters are now rejected before anything is written, with a message naming the offending character.

## Tests

New `tests/test_generated_code_is_valid.py`, 64 cases. Every one **compiles** the output rather than inspecting it:

- 8 hostile strings × 3 generators × description and parameter-description positions — double quote, single quote, newline, backslash, trailing quote, embedded `"""`, tab, unicode
- escaped text must still *survive* into the output, so escaping can't "pass" by mangling
- colliding parameter names compile, in all three generators
- unicode identifiers preserved; every prior sanitiser case re-asserted
- `init` rejects hostile names **and leaves no directory behind**
- all three scaffold types compile

17 fail without the escaping and `init` fixes.

`make check` green: **334 passed**.
