### PR TITLE
release: v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,63 @@ release assembles them here — run `make changelog-draft` to preview them.
 
 <!-- towncrier release notes start -->
 
+## [0.5.1] - 2026-08-14
+
+### Added
+
+- `AGENTS.md` documents the codebase for coding agents working on intpot — the pipeline,
+  the `ToolInfo` contract, the contribution workflow, the review criteria, and the
+  conventions that exist because breaking them shipped real bugs. `docs/reviewing.md`
+  covers the review procedure itself. Both are read by every agent and by humans; nothing
+  tool-specific is kept in the repository. ([#66](https://github.com/tugrulguner/intpot/pull/66))
+
+### Changed
+
+- The roadmap now reflects what is built. It described basic body transforms, return-type
+  coercion, round-trip tests and import resolution as future v2 work months after they
+  shipped, and still labelled 0.4 as current. Remaining items link to their issues. ([#68](https://github.com/tugrulguner/intpot/pull/68))
+
+### Fixed
+
+- The CLI reference in the README now covers every command and flag. `intpot inspect` had
+  no section at all, `--dry-run` and `--verbose` went unmentioned on the conversion
+  commands, and `serve --cli` was still documented as though it could not take arguments. ([#64](https://github.com/tugrulguner/intpot/pull/64))
+- The skills installed by `intpot add skills` now describe the current API. They had not
+  been updated since 0.3.0 and covered only the conversion commands — an agent reading them
+  learned nothing about `intpot.App`, `@app.tool`, `serve` or `eject`, and one example
+  referenced a `ParameterInfo.annotation` field that does not exist. ([#65](https://github.com/tugrulguner/intpot/pull/65))
+- `intpot add skills --agent claude` now installs skills Claude Code can actually find. It
+  wrote a flat `.claude/skills/intpot-cli.md` with no YAML frontmatter; Claude Code
+  discovers skills as `.claude/skills/<name>/SKILL.md` and reads the frontmatter to decide
+  relevance, so the installed files were never loaded. The other five agents were
+  unaffected. ([#67](https://github.com/tugrulguner/intpot/pull/67))
+- FastAPI endpoints named `root` are no longer dropped during conversion. Built-in routes
+  were filtered by function name and `root` was on that list, so the usual handler for `/`
+  silently disappeared from every conversion. FastAPI's own documentation routes are now
+  excluded by route type instead, which is exact. ([#70](https://github.com/tugrulguner/intpot/pull/70))
+- Tools written on a single line — `def double(x: int) -> int: return x * 2` — now convert
+  correctly. The extracted body included the `def` line itself, so the generated command or
+  endpoint defined a nested function and never called it, producing no output at all. ([#71](https://github.com/tugrulguner/intpot/pull/71))
+- `intpot add skills` no longer installs into projects that use no AI agent. `.github/` was
+  treated as evidence of Copilot and `AGENTS.md` as evidence of Codex, so an ordinary repo
+  with a CI workflow had intpot's skills appended to its own AGENTS.md. Copilot is now
+  detected from `.github/copilot-instructions.md`, and Codex must be requested with
+  `--agent codex`. ([#72](https://github.com/tugrulguner/intpot/pull/72))
+- Generated and scaffolded FastAPI servers now bind `127.0.0.1` instead of `0.0.0.0`.
+  `intpot serve --api` already defaulted to loopback, but `eject --to api` and
+  `init --type api` produced files that listened on every network interface. ([#73](https://github.com/tugrulguner/intpot/pull/73))
+- Typer apps are readable again on typer 0.27, which vendors its own copy of click. Every
+  `isinstance` and identity check against the standalone `click` package stopped matching,
+  so `intpot inspect`, `to mcp`, `to api` and `to cli` found no tools at all in any Typer
+  source, and would have typed every parameter `str` had they found them. ([#77](https://github.com/tugrulguner/intpot/pull/77))
+- Generated code now parses regardless of what the source app contains. A parameter
+  description holding a quote, newline or backslash produced an unterminated string literal
+  from `to cli` and `to api`; two parameters whose names sanitised onto the same identifier
+  produced a duplicate argument; non-ASCII names like `café` were mangled to `caf_`; and
+  `intpot init` accepted project names containing quotes, scaffolding a project that would
+  not parse. ([#79](https://github.com/tugrulguner/intpot/pull/79))
+
+
 ## [0.5.0] - 2026-08-10
 
 ### Changed

--- a/changelog.d/64.fixed.md
+++ b/changelog.d/64.fixed.md
@@ -1,3 +1,0 @@
-The CLI reference in the README now covers every command and flag. `intpot inspect` had
-no section at all, `--dry-run` and `--verbose` went unmentioned on the conversion
-commands, and `serve --cli` was still documented as though it could not take arguments.

--- a/changelog.d/65.fixed.md
+++ b/changelog.d/65.fixed.md
@@ -1,4 +1,0 @@
-The skills installed by `intpot add skills` now describe the current API. They had not
-been updated since 0.3.0 and covered only the conversion commands — an agent reading them
-learned nothing about `intpot.App`, `@app.tool`, `serve` or `eject`, and one example
-referenced a `ParameterInfo.annotation` field that does not exist.

--- a/changelog.d/66.added.md
+++ b/changelog.d/66.added.md
@@ -1,4 +1,0 @@
-`AGENTS.md` documents the codebase for coding agents working on intpot — the pipeline,
-the `ToolInfo` contract, the contribution workflow, and the conventions that exist
-because breaking them shipped real bugs. `CLAUDE.md` points at it, and the repo's own
-Claude skills are now tracked rather than living only on one machine.

--- a/changelog.d/67.fixed.md
+++ b/changelog.d/67.fixed.md
@@ -1,5 +1,0 @@
-`intpot add skills --agent claude` now installs skills Claude Code can actually find. It
-wrote a flat `.claude/skills/intpot-cli.md` with no YAML frontmatter; Claude Code
-discovers skills as `.claude/skills/<name>/SKILL.md` and reads the frontmatter to decide
-relevance, so the installed files were never loaded. The other five agents were
-unaffected.

--- a/changelog.d/68.changed.md
+++ b/changelog.d/68.changed.md
@@ -1,3 +1,0 @@
-The roadmap now reflects what is built. It described basic body transforms, return-type
-coercion, round-trip tests and import resolution as future v2 work months after they
-shipped, and still labelled 0.4 as current. Remaining items link to their issues.

--- a/changelog.d/70.fixed.md
+++ b/changelog.d/70.fixed.md
@@ -1,4 +1,0 @@
-FastAPI endpoints named `root` are no longer dropped during conversion. Built-in routes
-were filtered by function name and `root` was on that list, so the usual handler for `/`
-silently disappeared from every conversion. FastAPI's own documentation routes are now
-excluded by route type instead, which is exact.

--- a/changelog.d/71.fixed.md
+++ b/changelog.d/71.fixed.md
@@ -1,3 +1,0 @@
-Tools written on a single line — `def double(x: int) -> int: return x * 2` — now convert
-correctly. The extracted body included the `def` line itself, so the generated command or
-endpoint defined a nested function and never called it, producing no output at all.

--- a/changelog.d/72.fixed.md
+++ b/changelog.d/72.fixed.md
@@ -1,5 +1,0 @@
-`intpot add skills` no longer installs into projects that use no AI agent. `.github/` was
-treated as evidence of Copilot and `AGENTS.md` as evidence of Codex, so an ordinary repo
-with a CI workflow had intpot's skills appended to its own AGENTS.md. Copilot is now
-detected from `.github/copilot-instructions.md`, and Codex must be requested with
-`--agent codex`.

--- a/changelog.d/73.fixed.md
+++ b/changelog.d/73.fixed.md
@@ -1,3 +1,0 @@
-Generated and scaffolded FastAPI servers now bind `127.0.0.1` instead of `0.0.0.0`.
-`intpot serve --api` already defaulted to loopback, but `eject --to api` and
-`init --type api` produced files that listened on every network interface.

--- a/changelog.d/77.fixed.md
+++ b/changelog.d/77.fixed.md
@@ -1,4 +1,0 @@
-Typer apps are readable again on typer 0.27, which vendors its own copy of click. Every
-`isinstance` and identity check against the standalone `click` package stopped matching,
-so `intpot inspect`, `to mcp`, `to api` and `to cli` found no tools at all in any Typer
-source, and would have typed every parameter `str` had they found them.

--- a/changelog.d/79.fixed.md
+++ b/changelog.d/79.fixed.md
@@ -1,6 +1,0 @@
-Generated code now parses regardless of what the source app contains. A parameter
-description holding a quote, newline or backslash produced an unterminated string literal
-from `to cli` and `to api`; two parameters whose names sanitised onto the same identifier
-produced a duplicate argument; non-ASCII names like `café` were mangled to `caf_`; and
-`intpot init` accepted project names containing quotes, scaffolding a project that would
-not parse.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "intpot"
-version = "0.5.0"
+version = "0.5.1"
 description = "Define Python tools once and serve them as a Typer CLI, FastAPI app, or FastMCP server — or convert existing apps between all three"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -651,7 +651,7 @@ wheels = [
 
 [[package]]
 name = "intpot"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Eleven fragments assembled, version bumped, lockfile relocked. Everything verified against a clean install of the built wheel before this branch was cut.

## Why now

**0.5.0 on PyPI cannot read a Typer app on a fresh install.** typer 0.27 vendors its own copy of click, so every `isinstance` check against the standalone package stopped matching and `inspect`, `to cli`, `to mcp` and `to api` return no tools at all — silently, with "No tools found". That's half the product. #77 fixes it; this ships it.

## What's in it

| PR | Fix |
|---|---|
| #77 | Typer apps readable again on typer 0.27 |
| #70 | FastAPI endpoints named `root` no longer silently dropped |
| #71 | One-line bodies no longer generate a nested function nothing calls |
| #72 | `add skills` no longer installs into projects using no agent |
| #73 | Generated and scaffolded API servers bind loopback, not every interface |
| #79 | Generated code parses whatever the source contains |
| #64, #65, #67, #66, #68 | CLI reference, shipped skills, Claude skill layout, AGENTS.md, roadmap |

## Pre-release verification

The wheel was installed into a clean venv with current dependencies — typer 0.27.1, fastapi 0.141.1, fastmcp 3.4.7 — and exercised as a user would, executing every artifact rather than inspecting it:

- `init` × 3 → CLI runs, MCP imports, API returns 200
- `inspect` × 3 sources → 2 tools each (the #77 regression, confirmed fixed)
- **all six conversions** → generate, compile, and compute the right answer
- `eject` × 3 → ejected CLI runs, ejected API responds
- `serve --cli` with forwarded args and defaults; `serve --api` live over HTTP, with `lsof` confirming `127.0.0.1` only
- `add skills` × 6 agents; Claude layout at `.claude/skills/<name>/SKILL.md`
- a plain CI repo correctly refused, its `AGENTS.md` byte-identical
- round-trip cli → mcp → cli still computes

The release gate (`verify-version`) was run locally against `v0.5.1`: tag format, version match and changelog section all pass, and the notes extract cleanly at 53 lines.

`make check`: **339 passed**.

## One correction made while assembling

The #66 fragment claimed the repo's Claude skills are tracked and that `CLAUDE.md` points at `AGENTS.md`. #69 deleted both and carried `skip-changelog`, so nothing had corrected the wording — it would have shipped a false statement. Rewritten to describe what's actually there.

## Known, not fixed here

Directory conversion silently overwrites output when two source files share a basename (`a/tools.py` and `b/tools.py` both write `tools_mcp.py`, and it prints two success lines). Reproduced during verification. Pre-existing, needs a decision on output naming, and shouldn't hold up a release that unbreaks Typer input.

## After merge

```bash
git checkout main && git pull
git tag v0.5.1 && git push origin v0.5.1
```

That triggers `release.yml`: gate → build → PyPI via trusted publishing → GitHub Release with notes from the changelog and the wheel and sdist attached.
