### PR TITLE
docs: bring the docs back in line with 0.5.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,27 @@ runtime 500, not a type-checker complaint.
 **Detection executes user code.** `detect_source` imports the module. Anything that scans
 many files must tolerate one of them raising — see `core/discovery.py`.
 
+**Identify framework objects structurally, never with `isinstance`.** typer 0.26 vendored
+its own copy of click as `typer._click`, so a Typer app stopped being an instance of
+anything in the standalone `click` package. Every check written against click failed at
+once: the inspector found zero tools in any Typer app, silently, for two and a half
+months. Match on what an object *has* — a `commands` mapping, a type's `name` — the way
+`detector.py` and `_is_depends` already do. The same applies to any framework we don't
+control, which is all of them.
+
+**Generated code must parse whatever the source contains.** Descriptions, parameter names
+and project names all come from someone else's code. A quote or newline in a description
+produced an unterminated string literal; two parameter names sanitising onto one
+identifier produced a duplicate argument. Never hand-write quotes around interpolated
+text — use the `repr` filter, which is Python's own literal writer. Tests must `compile()`
+the output, not inspect it.
+
+**A guard that can collect nothing must assert it found something.** The test asserting
+every CLI flag appears in the README derives its cases by walking the command tree. When
+that walk broke, the test quietly went from 22 assertions to 1 and kept reporting green —
+worse than having no test, because it still looked like coverage. Any parametrised test
+whose inputs come from introspection needs a floor on what discovery returns.
+
 ## Reviewing a change
 
 The rules above came from bugs that shipped — check those first. Beyond them, these are

--- a/README.md
+++ b/README.md
@@ -544,14 +544,23 @@ intpot add skills [--agent <name>] [--path <dir>]
 
 **Supported agents and output locations:**
 
-| Agent | Files created |
-|-------|--------------|
-| Claude Code | `.claude/skills/intpot-cli/SKILL.md`, `.claude/skills/intpot-python/SKILL.md` |
-| Cursor | `.cursor/rules/intpot-cli.mdc`, `.cursor/rules/intpot-python.mdc` |
-| Windsurf | `.windsurf/rules/intpot-cli.md`, `.windsurf/rules/intpot-python.md` |
-| GitHub Copilot | `.github/copilot-instructions.md` (appended) |
-| Cline | `.clinerules/intpot-cli.md`, `.clinerules/intpot-python.md` |
-| OpenAI Codex | `AGENTS.md` (appended) |
+| Agent | Detected by | Files created |
+|-------|-------------|--------------|
+| Claude Code | `.claude/` | `.claude/skills/intpot-cli/SKILL.md`, `.claude/skills/intpot-python/SKILL.md` |
+| Cursor | `.cursor/` | `.cursor/rules/intpot-cli.mdc`, `.cursor/rules/intpot-python.mdc` |
+| Windsurf | `.windsurf/` | `.windsurf/rules/intpot-cli.md`, `.windsurf/rules/intpot-python.md` |
+| GitHub Copilot | `.github/copilot-instructions.md` | `.github/copilot-instructions.md` (appended) |
+| Cline | `.clinerules/` | `.clinerules/intpot-cli.md`, `.clinerules/intpot-python.md` |
+| OpenAI Codex | never auto-detected | `AGENTS.md` (appended) |
+
+**Codex has to be asked for by name** — `intpot add skills --agent codex`. It reads
+`AGENTS.md`, but so does nearly every other tool now, so the presence of that file says
+nothing about whether you use Codex. Since installing appends to it, guessing wrong would
+edit your own documentation. The same reasoning is why Copilot keys off
+`.github/copilot-instructions.md` rather than `.github/`, which only means the project is
+on GitHub.
+
+Running with no `--agent` and no detected marker exits without writing anything.
 
 ## Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,9 @@ existing Typer, FastMCP, and FastAPI apps.
 ### Remaining polish
 
 - [ ] Handle `Annotated[str, Body(...)]` style FastAPI parameters ([#1](https://github.com/tugrulguner/intpot/issues/1))
-- [ ] Support Click groups / Typer sub-apps, i.e. nested command hierarchies ([#2](https://github.com/tugrulguner/intpot/issues/2))
+- [ ] Emit nested command hierarchies. Reading them works; see "Already shipped". What's
+      missing is the other direction — generating a Typer sub-app rather than a flat
+      command ([#2](https://github.com/tugrulguner/intpot/issues/2))
 - [ ] Preserve parameter descriptions through all conversion directions ([#3](https://github.com/tugrulguner/intpot/issues/3), [#9](https://github.com/tugrulguner/intpot/issues/9))
 - [ ] `--all` mode for `intpot serve` — serve CLI, API, and MCP simultaneously ([#32](https://github.com/tugrulguner/intpot/issues/32))
 
@@ -24,6 +26,9 @@ than planned:
 - **Return-type coercion for FastAPI** — a scalar return is wrapped as
   `{"result": ...}` so the generated handler matches the response model FastAPI validates
   against.
+- **Reading nested command hierarchies** — `app.add_typer(db, name="db")` is walked to any
+  depth and each command extracted, named by its path: `db migrate` becomes `db_migrate`.
+  Generating a nested hierarchy back out is still open (#2).
 - **Round-trip fidelity tests** — `tests/test_roundtrip.py` covers all three pairings.
 - **Direct import resolution** — imports referenced by a function body are carried into
   the generated file. Transitive dependencies are not yet followed.

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -40,10 +40,30 @@ From `AGENTS.md`, then general correctness and security review on top.
 
 Always `make check` before signing off. While iterating, the narrower runs are:
 
+`make check` resolves from `uv.lock`, so it proves the change works against the pinned
+dependencies — not against what a user installing today would get. If you touch code that
+reaches into a third-party framework's internals, run it against current releases too:
+
+```bash
+PYTHONPATH=$PWD/src uv run --no-project \
+  --with typer --with fastapi --with fastmcp --with uvicorn --with jinja2 \
+  --with pytest --with pytest-cov --with httpx \
+  pytest tests/ -q
+```
+
+`--with <name>` resolves the newest release, and `--no-project` keeps the lockfile out of
+it. As of 0.5.1 that passes: 340 tests against typer 0.27.1, fastapi 0.141.1 and
+fastmcp 3.4.7.
+
+A pinned lockfile is why the typer 0.26 breakage sat undetected for two and a half months
+while CI stayed green.
+
+
 | Changed | Run |
 |---|---|
 | `src/intpot/core/inspectors/` | `.venv/bin/pytest tests/test_inspectors/ -x` |
-| `src/intpot/core/generators/` or `src/intpot/templates/` | `.venv/bin/pytest tests/test_generators/ -x` |
+| `src/intpot/core/generators/` or `src/intpot/templates/` | `.venv/bin/pytest tests/test_generators/ tests/test_generated_code_is_valid.py -x` |
+| `src/intpot/core/inspectors/_utils.py` | `.venv/bin/pytest tests/test_inspectors/test_utils.py -x` |
 | `src/intpot/commands/` or `src/intpot/cli.py` | `.venv/bin/pytest tests/test_commands/ -x` |
 | `src/intpot/core/transforms.py` | `.venv/bin/pytest tests/test_roundtrip.py tests/test_transforms.py -x` |
 | `src/intpot/runtime.py`, `src/intpot/runtime_builders.py` | `.venv/bin/pytest tests/test_runtime.py tests/test_runtime_builders.py -x` |

--- a/src/intpot/templates/skills/intpot-cli.md
+++ b/src/intpot/templates/skills/intpot-cli.md
@@ -96,6 +96,8 @@ Prefer `--json` when you need to reason about the result programmatically.
   module to find the app instance, so module-level code runs. Use `--dry-run` on
   unfamiliar code.
 - **`serve --api` binds `127.0.0.1`.** Pass `--host 0.0.0.0` to expose it on the network.
+  Code from `eject --to api` and `init --type api` binds loopback too; change the `host=`
+  argument in the generated file to opt in.
 - **`serve --api` reads arguments from a JSON body**, not the query string — the same
   shape `eject --to api` generates.
 - **Converted code carries the original body over** where the frameworks agree, and


### PR DESCRIPTION
Audited the README, the shipped skills, `ROADMAP.md` and the internal review docs against what the code actually does after 0.5.1. Four had drifted. Each finding was verified by running something, not by reading.

## README — how agent detection works was never documented

It said `add skills` "auto-detects which agents are configured" and left it there. After #72 that's a real gap: Copilot keys off `.github/copilot-instructions.md` rather than `.github/`, and **Codex is not auto-detected at all**. Someone running it in a repo that has an `AGENTS.md` gets "no agents detected" with no explanation in the docs.

The table now has a *Detected by* column, plus the reasoning: `AGENTS.md` is a cross-tool convention so its presence says nothing about Codex, and since installing **appends** to that file, guessing wrong edits the user's own documentation.

## ROADMAP — nested hierarchies are half shipped

"Support Click groups / Typer sub-apps" sat under *Remaining polish*. Reading them works, and has for a while:

```
app.add_typer(db, name="db")   →   tools: ['top', 'db_migrate']
intpot to mcp                  →   db_migrate("v2") -> v2
```

Verified end to end — extracted, converted, and the generated MCP tool executed. What's genuinely missing is the reverse: generating a nested sub-app instead of a flat `db_migrate`. The entry now says that, and "Already shipped" describes the reading side.

**Issue #2 needs the same narrowing** — I haven't touched it, since those issues are deliberate contributor bait and rewording one is your call.

## AGENTS.md — three rules from this week's bugs

The "Rules that come from real bugs" section is where this repo records what it learned. Three were missing:

- **Identify framework objects structurally, never with `isinstance`.** typer 0.26 vendored click as `typer._click`; every check written against the standalone package failed simultaneously and the inspector found zero tools in any Typer app, silently, for two and a half months. Match on what an object *has*.
- **Generated code must parse whatever the source contains.** Never hand-write quotes around interpolated text; use the `repr` filter. Tests must `compile()` the output.
- **A guard that can collect nothing must assert it found something.** The README flag check went from 22 parametrised assertions to 1 and kept reporting green — worse than no test, because it still looks like coverage.

## docs/reviewing.md — test map, and testing against reality

The map missed `test_generated_code_is_valid.py` and `test_inspectors/test_utils.py`.

More importantly it now carries a command for running the suite against **current releases** rather than the lockfile, because a pinned lockfile is exactly why typer 0.26 went unnoticed while CI stayed green:

```bash
PYTHONPATH=$PWD/src uv run --no-project \
  --with typer --with fastapi --with fastmcp --with uvicorn --with jinja2 \
  --with pytest --with pytest-cov --with httpx \
  pytest tests/ -q
```

My first draft of that used `--with 'typer@latest'`, which uv reads as a local file path and fails. Caught by running it. The committed version is the one I ran: **340 passed** against typer 0.27.1, fastapi 0.141.1, fastmcp 3.4.7.

## Shipped skill

`intpot-cli.md` now notes that `eject --to api` and `init --type api` output binds loopback too, which changed in #73.

---

`make check`: 340 passed. Not user-facing, so `skip-changelog`.
