### PR TITLE
fix: stop annotating None-returning tools as returning str

### DIFF
--- a/changelog.d/83.fixed.md
+++ b/changelog.d/83.fixed.md
@@ -1,0 +1,4 @@
+Tools that return nothing are no longer annotated as returning `str`. An ejected FastAPI
+endpoint over a body returning `None` failed response validation on every call — a 500 —
+and a tool with no return annotation did the same as soon as it returned a non-string.
+`-> None` now stays `None`, and an unannotated return becomes `Any`.

--- a/src/intpot/core/inspectors/_utils.py
+++ b/src/intpot/core/inspectors/_utils.py
@@ -21,6 +21,25 @@ def python_type_name(annotation: Any) -> str:
     return text
 
 
+def python_return_type_name(annotation: Any) -> str:
+    """Name a tool's return annotation, keeping "nothing" distinct from "unknown".
+
+    `python_type_name` answers both with "str". That is a fair default for an
+    unannotated *parameter* and wrong for a return type: FastAPI validates the
+    response against this annotation, so `-> str` over a function returning
+    `None` is a 500 on every call rather than a type-checker complaint.
+
+    - `-> None` becomes `"None"`, which FastAPI accepts.
+    - No annotation at all becomes `"Any"`, which tells FastAPI not to constrain
+      the response — the only honest answer when the source never said.
+    """
+    if annotation is inspect.Parameter.empty:
+        return "Any"
+    if annotation is None or annotation is type(None):
+        return "None"
+    return python_type_name(annotation)
+
+
 def extract_source_imports(fn: Any) -> list[str]:
     """Extract imports from the source file that are referenced in the function body.
 

--- a/src/intpot/core/inspectors/api.py
+++ b/src/intpot/core/inspectors/api.py
@@ -10,6 +10,7 @@ from typing import Any
 from intpot.core.inspectors._utils import (
     extract_function_body,
     extract_source_imports,
+    python_return_type_name,
     python_type_name,
 )
 from intpot.core.inspectors.base import BaseInspector
@@ -146,7 +147,7 @@ class APIInspector(BaseInspector):
                 )
 
             return_annotation = type_hints.get("return", sig.return_annotation)
-            return_type = python_type_name(return_annotation)
+            return_type = python_return_type_name(return_annotation)
 
             tools.append(
                 ToolInfo(

--- a/src/intpot/core/inspectors/mcp.py
+++ b/src/intpot/core/inspectors/mcp.py
@@ -9,6 +9,7 @@ from typing import Any
 from intpot.core.inspectors._utils import (
     extract_function_body,
     extract_source_imports,
+    python_return_type_name,
     python_type_name,
 )
 from intpot.core.inspectors.base import BaseInspector
@@ -83,7 +84,7 @@ class MCPInspector(BaseInspector):
                 )
 
             return_annotation = type_hints.get("return", sig.return_annotation)
-            return_type = python_type_name(return_annotation)
+            return_type = python_return_type_name(return_annotation)
 
             tools.append(
                 ToolInfo(

--- a/src/intpot/runtime.py
+++ b/src/intpot/runtime.py
@@ -11,6 +11,7 @@ from typing import Any
 from intpot.core.inspectors._utils import (
     extract_function_body,
     extract_source_imports,
+    python_return_type_name,
     python_type_name,
 )
 from intpot.core.models import _SENTINEL, ParameterInfo, ToolInfo
@@ -194,12 +195,10 @@ def _build_tool_info(
             )
         )
 
-    # Return type
+    # Return type. `-> None` and "no annotation" are different answers, and
+    # collapsing both to "str" made every ejected FastAPI endpoint 500.
     return_hint = hints.get("return", sig.return_annotation)
-    if return_hint is inspect.Parameter.empty or return_hint is None:
-        return_type = "str"
-    else:
-        return_type = python_type_name(return_hint)
+    return_type = python_return_type_name(return_hint)
 
     # Extract function body and imports for eject
     function_body = extract_function_body(func)

--- a/tests/test_return_types.py
+++ b/tests/test_return_types.py
@@ -1,0 +1,99 @@
+"""Return annotations must describe what the body actually returns.
+
+FastAPI validates the response against the annotation, so an annotation that
+overstates what comes back is a 500 on every call rather than a type-checker
+complaint. `-> None` and "no annotation at all" are different answers, and
+collapsing both onto `str` produced exactly that.
+"""
+
+from __future__ import annotations
+
+import inspect
+import warnings
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from intpot import App
+from intpot.core.inspectors._utils import python_return_type_name
+
+warnings.filterwarnings("ignore")
+
+
+def _eject_and_load(app: App, target: str) -> Any:
+    source = app.eject(target)
+    namespace: dict[str, Any] = {}
+    exec(compile(source, "<generated>", "exec"), namespace)
+    return source, namespace
+
+
+def test_no_annotation_is_unknown_not_str() -> None:
+    assert python_return_type_name(inspect.Parameter.empty) == "Any"
+
+
+def test_an_explicit_none_annotation_is_none() -> None:
+    assert python_return_type_name(None) == "None"
+    assert python_return_type_name(type(None)) == "None"
+
+
+def test_a_real_annotation_is_unchanged() -> None:
+    assert python_return_type_name(int) == "int"
+    assert python_return_type_name(str) == "str"
+
+
+def _app_with_awkward_returns() -> App:
+    app = App("t")
+
+    @app.tool()
+    def log_it(msg: str, level: str = "info") -> None:
+        """Returns nothing."""
+        return None
+
+    @app.tool()
+    def untyped(a: int, b: int):
+        """No return annotation."""
+        return a + b
+
+    return app
+
+
+def test_the_tool_info_distinguishes_none_from_unknown() -> None:
+    types = {t.name: t.return_type for t in _app_with_awkward_returns().tools}
+
+    assert types == {"log_it": "None", "untyped": "Any"}
+
+
+def test_an_ejected_endpoint_returning_none_does_not_500() -> None:
+    """The regression: `-> str` over a body returning None is a 500 on every call."""
+    source, namespace = _eject_and_load(_app_with_awkward_returns(), "api")
+    client = TestClient(namespace["app"])
+
+    response = client.post("/log_it", json={"msg": "x", "level": "warn"})
+
+    assert response.status_code == 200, response.text
+    assert response.json() is None
+    assert ") -> None:" in source
+
+
+def test_an_ejected_endpoint_without_an_annotation_returns_its_value() -> None:
+    source, namespace = _eject_and_load(_app_with_awkward_returns(), "api")
+    client = TestClient(namespace["app"])
+
+    response = client.post("/untyped", json={"a": 2, "b": 3})
+
+    assert response.status_code == 200, response.text
+    assert response.json() == 5
+    assert ") -> Any:" in source
+
+
+def test_any_is_imported_into_the_generated_module() -> None:
+    """An annotation nothing imports is a NameError at import time."""
+    source, _ = _eject_and_load(_app_with_awkward_returns(), "api")
+
+    assert "from typing import Any" in source
+
+
+@pytest.mark.parametrize("target", ["cli", "mcp", "api"])
+def test_every_target_still_generates_importable_code(target: str) -> None:
+    _eject_and_load(_app_with_awkward_returns(), target)


### PR DESCRIPTION
Consolidated review item **5**. Reproduced, and it is a 500 on every call to an affected endpoint.

## The failure

```python
@app.tool()
def log_it(msg: str, level: str = "info") -> None:
    """Returns nothing."""
    return None
```

`intpot eject --to api` generated `-> str`, and FastAPI validates the response against the annotation:

```
fastapi.exceptions.ResponseValidationError: 1 validation error:
  {'type': 'string_type', 'loc': ('response',), 'msg': 'Input should be a valid string', 'input': None}
```

A tool with **no** return annotation had the same problem the moment it returned anything non-string — `untyped(a, b) -> a + b` also 500'd.

## Cause

`python_type_name` answers both "no annotation" and `-> None` with `"str"`:

```python
if annotation is inspect.Parameter.empty or annotation is None:
    return "str"
```

That is a reasonable default for an unannotated **parameter** — a CLI argument really is a string. It is wrong for a return type, where the annotation is a contract FastAPI enforces.

## Fix

A separate `python_return_type_name` keeps the two apart:

| source | before | after |
|---|---|---|
| `-> None` | `str` | `None` |
| no annotation | `str` | `Any` |
| `-> int` | `int` | `int` |

`Any` is the honest answer when the source never said, and it tells FastAPI not to constrain the response. It was already in the generator's typing-import scan, so `from typing import Any` appears in the generated module — verified, since an annotation nothing imports is a `NameError` at import time.

Parameters keep using `python_type_name` and are unaffected.

## Why the existing tests passed

The live `serve --api` path never had this failure: `runtime_builders` does not derive a response model from `return_type`, so serving a `-> None` tool returns `200 null` even on `main`. Only **ejected and generated** code carries the annotation into FastAPI. The runtime tests were exercising the one path where the bug is invisible.

## Tests

`tests/test_return_types.py`, 10 cases, executing the generated app rather than reading it:

- the mapping itself, for all three input shapes
- `ToolInfo.return_type` distinguishes `None` from `Any`
- **an ejected `-> None` endpoint returns 200 and `null`** — the regression
- an ejected unannotated endpoint returns its actual value (`5`, not a 500)
- `from typing import Any` is present in the generated module
- all three targets still generate importable code

Four fail with the call sites reverted (keeping the new helper so the import resolves).

`make check`: **350 passed**.
