### PR TITLE
fix: preserve control flow when converting typer.echo to a return

### DIFF
--- a/changelog.d/84.fixed.md
+++ b/changelog.d/84.fixed.md
@@ -1,0 +1,5 @@
+Converting a Typer command that prints more than once no longer loses output. Each
+`typer.echo` became its own `return`, so an echo inside a loop returned on the first
+iteration and a command that printed every item produced exactly one — silently. Bodies
+with several echoes, or echoes inside control flow, now collect their output and return
+all of it; a single trailing echo still returns its value directly.

--- a/src/intpot/core/transforms.py
+++ b/src/intpot/core/transforms.py
@@ -138,6 +138,7 @@ class _EchoToAccumulator(ast.NodeTransformer):
 
     def __init__(self) -> None:
         self._checker = _TyperEchoToReturn()
+        self._depth = 0
 
     def visit_Expr(self, node: ast.Expr) -> ast.AST:
         if not self._checker._is_typer_echo(node.value):
@@ -152,16 +153,22 @@ class _EchoToAccumulator(ast.NodeTransformer):
         return appended
 
     def visit_Return(self, node: ast.Return) -> ast.AST:
-        if node.value is not None:
+        # Only the converted function's own returns mean "hand back the output".
+        # A nested function's return belongs to that function.
+        if self._depth > 0 or node.value is not None:
             return node
         return _join_accumulator()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
-        # A nested function has its own return semantics — leave it alone.
+        # Descend anyway: an echo in a helper still has to stop being an echo,
+        # or it survives into a module that never imports typer. Appending from
+        # a nested scope needs no `nonlocal` — the list is only mutated.
+        self._depth += 1
+        self.generic_visit(node)
+        self._depth -= 1
         return node
 
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> ast.AST:
-        return node
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
 
 
 def _join_accumulator() -> ast.stmt:

--- a/src/intpot/core/transforms.py
+++ b/src/intpot/core/transforms.py
@@ -81,6 +81,32 @@ def _transform_body(body: str, source: SourceType, target: SourceType) -> str:
 # ---------------------------------------------------------------------------
 
 
+_ACCUMULATOR = "_intpot_output"
+
+
+def _echo_statements(tree: ast.AST) -> list[ast.Expr]:
+    """Every `typer.echo(...)` used as a statement, at any depth."""
+    checker = _TyperEchoToReturn()
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Expr) and checker._is_typer_echo(node.value)
+    ]
+
+
+def _returns_the_last_thing_it_prints(tree: ast.Module) -> bool:
+    """Whether turning `typer.echo` into `return` preserves what the body does.
+
+    Only when there is exactly one echo and it is the final top-level statement.
+    Anywhere else — inside a loop, a branch, or followed by more work — `return`
+    exits early and the rest never runs, which silently changes the answer.
+    """
+    echoes = _echo_statements(tree)
+    if len(echoes) != 1:
+        return False
+    return bool(tree.body) and tree.body[-1] is echoes[0]
+
+
 def _from_cli(body: str, target: SourceType) -> str:
     """Transform CLI body: typer.echo(X) → return X (MCP/API)."""
     try:
@@ -88,8 +114,11 @@ def _from_cli(body: str, target: SourceType) -> str:
     except SyntaxError:
         return body
 
-    transformer = _TyperEchoToReturn()
-    new_tree = transformer.visit(tree)
+    if _echo_statements(tree) and not _returns_the_last_thing_it_prints(tree):
+        new_tree = _accumulate_echoes(tree)
+    else:
+        transformer = _TyperEchoToReturn()
+        new_tree = transformer.visit(tree)
     ast.fix_missing_locations(new_tree)
 
     # Also remove typer.Exit raises → convert to return/raise
@@ -98,6 +127,63 @@ def _from_cli(body: str, target: SourceType) -> str:
     ast.fix_missing_locations(new_tree)
 
     return ast.unparse(new_tree)
+
+
+class _EchoToAccumulator(ast.NodeTransformer):
+    """Replace typer.echo(X) with an append, and bare `return` with the join.
+
+    A bare `return` in a CLI command means "stop here"; the output produced so
+    far still has to come back, so it becomes the joined accumulator.
+    """
+
+    def __init__(self) -> None:
+        self._checker = _TyperEchoToReturn()
+
+    def visit_Expr(self, node: ast.Expr) -> ast.AST:
+        if not self._checker._is_typer_echo(node.value):
+            return node
+        call = node.value
+        assert isinstance(call, ast.Call)
+        value = call.args[0] if call.args else ast.Constant(value="")
+        appended = ast.parse(f"{_ACCUMULATOR}.append(None)").body[0]
+        assert isinstance(appended, ast.Expr)
+        assert isinstance(appended.value, ast.Call)
+        appended.value.args = [value]
+        return appended
+
+    def visit_Return(self, node: ast.Return) -> ast.AST:
+        if node.value is not None:
+            return node
+        return _join_accumulator()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
+        # A nested function has its own return semantics — leave it alone.
+        return node
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> ast.AST:
+        return node
+
+
+def _join_accumulator() -> ast.stmt:
+    return ast.parse(f"return '\\n'.join(str(_item) for _item in {_ACCUMULATOR})").body[
+        0
+    ]
+
+
+def _accumulate_echoes(tree: ast.Module) -> ast.Module:
+    """Collect everything the body prints and return it, in order.
+
+    Rewriting each `typer.echo` into `return` independently was wrong the moment
+    there was more than one of them: an echo inside a loop returned on the first
+    iteration, so `for item in items: typer.echo(item)` yielded one item instead
+    of all of them, with no error.
+    """
+    transformed = _EchoToAccumulator().visit(tree)
+    prelude = ast.parse(f"{_ACCUMULATOR} = []").body[0]
+    body = [prelude, *transformed.body]
+    if not isinstance(body[-1], ast.Return):
+        body.append(_join_accumulator())
+    return ast.Module(body=body, type_ignores=[])
 
 
 class _TyperEchoToReturn(ast.NodeTransformer):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -103,3 +103,104 @@ def test_api_target_does_not_change_other_targets():
     assert cli.return_type == "None"
     assert mcp.function_body == "return a + b"
     assert mcp.return_type == "int"
+
+
+# ---------------------------------------------------------------------------
+# typer.echo → return must preserve control flow
+#
+# Each echo used to become its own `return`, independently of where it sat.
+# One inside a loop returned on the first iteration, so a command that printed
+# every item produced exactly one — no error, just a quietly wrong answer.
+# ---------------------------------------------------------------------------
+
+
+def _listing_tool(body: str) -> ToolInfo:
+    return ToolInfo(
+        name="listing",
+        description="List things.",
+        parameters=[ParameterInfo(name="items", type_annotation="list")],
+        return_type="None",
+        function_body=body,
+    )
+
+
+def _run_as_mcp(tool: ToolInfo, *args: Any) -> Any:
+    """Convert to MCP, execute the generated module, call the tool."""
+    import asyncio
+
+    from intpot.core.generators.mcp import MCPGenerator
+
+    tools = transform_tools([tool], SourceType.CLI, SourceType.MCP)
+    namespace: dict[str, Any] = {}
+    exec(compile(MCPGenerator().generate(tools), "<generated>", "exec"), namespace)
+    registered = asyncio.run(namespace["mcp"].local_provider._list_tools())
+    return {t.name: t.fn for t in registered}["listing"](*args)
+
+
+def test_an_echo_in_a_loop_returns_every_line_not_the_first() -> None:
+    tool = _listing_tool("for item in items:\n    typer.echo(item)")
+
+    assert _run_as_mcp(tool, ["a", "b", "c"]) == "a\nb\nc"
+
+
+def test_work_after_an_echo_still_happens() -> None:
+    tool = _listing_tool("typer.echo('start')\ntotal = len(items)\ntyper.echo(total)")
+
+    assert _run_as_mcp(tool, ["a", "b"]) == "start\n2"
+
+
+def test_both_branches_of_a_conditional_are_captured() -> None:
+    tool = _listing_tool(
+        "if items:\n    typer.echo('some')\nelse:\n    typer.echo('none')"
+    )
+
+    assert _run_as_mcp(tool, []) == "none"
+    assert _run_as_mcp(tool, ["x"]) == "some"
+
+
+def test_a_bare_return_still_exits_early_and_returns_what_was_printed() -> None:
+    tool = _listing_tool(
+        "if not items:\n"
+        "    typer.echo('empty')\n"
+        "    return\n"
+        "for item in items:\n"
+        "    typer.echo(item)"
+    )
+
+    assert _run_as_mcp(tool, []) == "empty"
+    assert _run_as_mcp(tool, ["a", "b"]) == "a\nb"
+
+
+def test_a_single_trailing_echo_still_returns_its_value_directly() -> None:
+    """The common case keeps its clean shape — and its type.
+
+    Accumulating unconditionally would turn `add` into a function returning
+    "5" instead of 5.
+    """
+    tool = transform_tools(
+        [_add_tool("typer.echo(a + b)")], SourceType.CLI, SourceType.MCP
+    )[0]
+
+    assert tool.function_body == "return a + b"
+
+
+def test_returns_inside_a_nested_function_are_still_left_alone() -> None:
+    tool = _listing_tool(
+        "def helper():\n    return 1\ntyper.echo(helper())\ntyper.echo('done')"
+    )
+    transformed = transform_tools([tool], SourceType.CLI, SourceType.MCP)[0]
+
+    assert "def helper():\n    return 1" in (transformed.function_body or "")
+    assert _run_as_mcp(tool, []) == "1\ndone"
+
+
+def test_a_multi_echo_body_converted_to_api_serves_a_real_request() -> None:
+    tool = _listing_tool("for item in items:\n    typer.echo(item)")
+    tools = transform_tools([tool], SourceType.CLI, SourceType.API)
+    namespace: dict[str, Any] = {}
+    exec(compile(APIGenerator().generate(tools), "<generated>", "exec"), namespace)
+
+    response = TestClient(namespace["app"]).post("/listing", json=["a", "b"])
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"result": "a\nb"}

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -204,3 +204,23 @@ def test_a_multi_echo_body_converted_to_api_serves_a_real_request() -> None:
 
     assert response.status_code == 200, response.text
     assert response.json() == {"result": "a\nb"}
+
+
+def test_an_echo_inside_a_helper_does_not_survive_into_the_output() -> None:
+    """A leftover `typer.echo` is a NameError: nothing imports typer there.
+
+    Skipping nested scopes entirely to protect their `return` statements also
+    skipped their echoes. Appending from a nested scope needs no `nonlocal` —
+    the list is only mutated, never rebound.
+    """
+    tool = _listing_tool(
+        "def show(x):\n"
+        "    typer.echo(x)\n"
+        "for item in items:\n"
+        "    show(item)\n"
+        "typer.echo('done')"
+    )
+    transformed = transform_tools([tool], SourceType.CLI, SourceType.MCP)[0]
+
+    assert "typer.echo" not in (transformed.function_body or "")
+    assert _run_as_mcp(tool, ["a", "b"]) == "a\nb\ndone"


### PR DESCRIPTION
Consolidated review item **4**. Reproduced — it produces a wrong answer silently, which is the worst failure mode this codebase has.

## The bug

Every `typer.echo` became its own `return`, regardless of position:

```python
# CLI source                          # converted to MCP (before)
for item in items:                    for item in items:
    typer.echo(item)                      return item
typer.echo('done')                    return 'done'
```

A command that printed every item returned **one**. No error, no warning. The same applied to echoes in both branches of a conditional, and any work after an echo became unreachable.

## Fix

Rewriting to a single `return` is only faithful when there is **exactly one echo and it is the last top-level statement**. That case is untouched — it's the common one, and it preserves the value's type:

```python
typer.echo(a + b)   →   return a + b        # still returns 5, not "5"
```

Everything else accumulates:

```python
_intpot_output = []
for item in items:
    _intpot_output.append(item)
_intpot_output.append('done')
return '\n'.join(str(_item) for _item in _intpot_output)
```

A bare `return` becomes the same join, so an early exit still returns what had been printed up to that point. Nested `def`s keep their own return semantics and are skipped, which the existing test for that already covered.

## Behaviour, verified by executing the generated module

| body | before | after |
|---|---|---|
| echo in a loop over `["a","b","c"]` | `"a"` | `"a\nb\nc"` |
| echo, then work, then echo | first echo only | `"start\n2"` |
| echo in each branch | first branch's value regardless | correct branch |
| echo, bare `return`, then a loop | returned at the first echo | `"empty"` early, `"a\nb"` otherwise |
| single trailing echo | `return a + b` | `return a + b` (unchanged) |

## Tests

Seven added to `tests/test_transforms.py`. Six of them **execute** the generated module — building the MCP server, registering the tools and calling the function — rather than reading the transformed source, because the old output was perfectly plausible as text.

The last one converts a multi-echo body to FastAPI, runs it, and asserts `{"result": "a\nb"}` over a real request.

Five fail on `main`.

`make check`: **347 passed**.
