### PR TITLE
docs: document what #86 and #87 changed, and the variadic limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ intpot eject <source> --to <cli|mcp|api> [--output <path>]
 |----------------|-------------|
 | `source` | Path to a Python file containing an `intpot.App` |
 | `--to`, `-t` | Target framework: `cli`, `mcp`, `api` (required) |
-| `--output`, `-o` | Output file path (prints to stdout if omitted) |
+| `--output`, `-o` | Output file path (prints to stdout if omitted). Missing parent directories are created |
 
 ### `intpot init`
 
@@ -512,7 +512,7 @@ All three take the same arguments:
 | Argument/Option | Description |
 |----------------|-------------|
 | `source` | Path to a source Python file or directory |
-| `--output`, `-o` | Output file/directory path (prints to stdout if omitted) |
+| `--output`, `-o` | Output file/directory path (prints to stdout if omitted). Missing directories are created |
 | `--dry-run` | Print what would be generated, without writing any files |
 | `--verbose`, `-v` | Print detection details to stderr |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,10 @@ than planned:
   `core/transforms.py`.
 - **Return-type coercion for FastAPI** — a scalar return is wrapped as
   `{"result": ...}` so the generated handler matches the response model FastAPI validates
-  against.
+  against. The annotation is derived from every reachable outcome of the body, not from
+  whether a `return` appears somewhere: a function that returns on one branch and falls
+  through on another is annotated `dict | None`, because FastAPI rejects the response
+  otherwise.
 - **Reading nested command hierarchies** — `app.add_typer(db, name="db")` is walked to any
   depth and each command extracted, named by its path: `db migrate` becomes `db_migrate`.
   Generating a nested hierarchy back out is still open (#2).
@@ -58,6 +61,9 @@ transformations that need real understanding of what a function body does.
 
 - Runtime interop / adapter layer (intpot is a code generator, not a runtime bridge)
 - Supporting frameworks beyond Typer, FastMCP, and FastAPI
+- **Variadic tool signatures.** `*args` and `**kwargs` have no representation that means
+  the same thing as a CLI argument, an HTTP request body, and an MCP tool schema, so
+  `@app.tool()` rejects them outright rather than guessing. Use explicit named parameters.
 
 ---
 


### PR DESCRIPTION
#83 through #88 largely documented themselves — the variadic note, the extras clarification and the `--dry-run` caveat all landed with their PRs. Three gaps were left.

## `--output` creates directories

#86 added `mkdir(parents=True)` for both the single-file and directory paths, but the CLI reference tables didn't mention it. Verified rather than assumed:

```
$ intpot to cli src.py -o deep/nested/cli.py     # from an empty directory
Generated CLI app: deep/nested/cli.py
```

Both `--output` rows now say missing directories are created.

## ROADMAP overstated what return-type coercion does

It described FastAPI coercion as "a scalar return is wrapped as `{"result": ...}`", which was the whole story until #87. It now derives the annotation from every reachable outcome, so a body that returns on one branch and falls through on another gets `dict | None`.

That's the part someone reading generated output would be surprised by, so it belongs in the description rather than only in a changelog entry.

## Variadics are a non-goal, not an omission

#88 made `@app.tool()` reject `*args`/`**kwargs`. The README says it happens; the roadmap now says it's permanent and why — those parameters have no representation that means the same thing as a CLI argument, an HTTP request body, and an MCP tool schema, so guessing would be worse than refusing.

Listing it under **Non-goals for v2** stops it reading as a gap someone might send a PR to close.

---

`make check`: 406 passed. Not user-facing, so `skip-changelog`.
