### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ release assembles them here — run `make changelog-draft` to preview them.
 
 <!-- towncrier release notes start -->
 
+## [0.6.0] - 2026-08-15
+
+### Changed
+
+- **Breaking:** `@app.tool()` now rejects functions with `*args` or `**kwargs`, raising
+  `ValueError` when the tool is registered — which is import time for most apps. Variadic
+  parameters have no representation that means the same thing as a CLI argument, an HTTP
+  request body, and an MCP tool schema, so intpot refuses rather than guessing. Replace them
+  with explicit named parameters. In the same change, positional-only parameters and
+  ordinary parameters named `self` or `cls` are now preserved and called correctly in all
+  three modes, where before they raised `TypeError` or were silently dropped. ([#88](https://github.com/tugrulguner/intpot/pull/88))
+
+### Fixed
+
+- Tools that return nothing are no longer annotated as returning `str`. An ejected FastAPI
+  endpoint over a body returning `None` failed response validation on every call — a 500 —
+  and a tool with no return annotation did the same as soon as it returned a non-string.
+  `-> None` now stays `None`, and an unannotated return becomes `Any`. ([#83](https://github.com/tugrulguner/intpot/pull/83))
+- Converting a Typer command that prints more than once no longer loses output. Each
+  `typer.echo` became its own `return`, so an echo inside a loop returned on the first
+  iteration and a command that printed every item produced exactly one — silently. Bodies
+  with several echoes, or echoes inside control flow, now collect their output and return
+  all of it; a single trailing echo still returns its value directly. ([#84](https://github.com/tugrulguner/intpot/pull/84))
+- Agent guidance installed by `intpot add skills` now uses valid activation metadata and updates shared files without overwriting project content. ([#85](https://github.com/tugrulguner/intpot/pull/85))
+- Single-file conversions now report detection failures clearly and create missing output directories. ([#86](https://github.com/tugrulguner/intpot/pull/86))
+- FastAPI conversions now accept functions that return values on only some control-flow paths. ([#87](https://github.com/tugrulguner/intpot/pull/87))
+
+
 ## [0.5.1] - 2026-08-14
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## v0.5 (current) — Write Once, Serve Everywhere
+## v0.6 (current) — Write Once, Serve Everywhere
 
 Define tools once with `@app.tool()` and serve them as a CLI, API, or MCP server, or
 eject them to standalone framework code. The converter handles all six directions between

--- a/changelog.d/83.fixed.md
+++ b/changelog.d/83.fixed.md
@@ -1,4 +1,0 @@
-Tools that return nothing are no longer annotated as returning `str`. An ejected FastAPI
-endpoint over a body returning `None` failed response validation on every call — a 500 —
-and a tool with no return annotation did the same as soon as it returned a non-string.
-`-> None` now stays `None`, and an unannotated return becomes `Any`.

--- a/changelog.d/84.fixed.md
+++ b/changelog.d/84.fixed.md
@@ -1,5 +1,0 @@
-Converting a Typer command that prints more than once no longer loses output. Each
-`typer.echo` became its own `return`, so an echo inside a loop returned on the first
-iteration and a command that printed every item produced exactly one — silently. Bodies
-with several echoes, or echoes inside control flow, now collect their output and return
-all of it; a single trailing echo still returns its value directly.

--- a/changelog.d/85.fixed.md
+++ b/changelog.d/85.fixed.md
@@ -1,1 +1,0 @@
-Agent guidance installed by `intpot add skills` now uses valid activation metadata and updates shared files without overwriting project content.

--- a/changelog.d/86.fixed.md
+++ b/changelog.d/86.fixed.md
@@ -1,1 +1,0 @@
-Single-file conversions now report detection failures clearly and create missing output directories.

--- a/changelog.d/87.fixed.md
+++ b/changelog.d/87.fixed.md
@@ -1,1 +1,0 @@
-FastAPI conversions now accept functions that return values on only some control-flow paths.

--- a/changelog.d/88.changed.md
+++ b/changelog.d/88.changed.md
@@ -1,1 +1,0 @@
-Universal apps now preserve positional-only and `self`/`cls` parameters and reject unsupported variadic signatures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "intpot"
-version = "0.5.1"
+version = "0.6.0"
 description = "Define Python tools once and serve them as a Typer CLI, FastAPI app, or FastMCP server — or convert existing apps between all three"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -651,7 +651,7 @@ wheels = [
 
 [[package]]
 name = "intpot"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Six PRs' worth of fixes plus one breaking change.

## Why minor, not patch

#88 makes `@app.tool()` raise `ValueError` on functions with `*args` or `**kwargs`, **at registration** — import time for most apps. Code that ran on 0.5.1 stops on upgrade.

Same call as 0.5.0, whose announcement opened with *"This is a minor rather than a patch release because two things change behaviour."*

## What's in it

| PR | |
|---|---|
| #88 | **Breaking:** variadic tool signatures rejected. Also fixes positional-only and `self`/`cls` parameters, which raised `TypeError` or were dropped |
| #83 | `-> None` tools were annotated `str` — a 500 on every call to an ejected endpoint |
| #84 | Multi-echo Typer commands returned only the first line; an echo in a loop returned on the first iteration |
| #87 | Bodies returning on only some paths are annotated `dict \| None` instead of failing response validation |
| #86 | Detection failures reported on stderr with exit 1; missing output directories created |
| #85 | Installed agent guidance uses valid activation metadata and updates shared files without overwriting project content |

## Upgrade note

Anyone keeping generated code in version control will see a diff on regeneration — `dict | None` annotations where a body can fall through, and accumulator-shaped bodies for multi-echo commands. In both cases the new output is what the old output should have been.

## One edit made while assembling

`88.changed.md` read "reject unsupported variadic signatures". That undersells a change whose symptom is an exception at import, and these fragments become both the release notes and the GitHub Release body. Rewritten to lead with **Breaking**, say when it fires, and say what to use instead.

## Verification

- `make check`: **406 passed**
- release gate simulated locally for `v0.6.0` — tag format, version match, changelog section all pass; notes extract at 24 lines
- `pyproject.toml`, `uv.lock` and `CHANGELOG.md` all agree on 0.6.0
- ROADMAP `(current)` heading moved to v0.6 per `docs/releasing.md`; nothing came off the polish list, since every entry here is a fix or a constraint rather than a planned feature

## After merge

```bash
git checkout main && git pull
git tag v0.6.0 && git push origin v0.6.0
```

I'd like to run the same clean-venv verification against the built wheel before tagging, as with 0.5.1 — install from the artifact and exercise all six conversions, both serve modes and `add skills`, rather than trusting the suite.
