### PR TITLE
docs: fix internal review guidance link

### DIFF
--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -1,7 +1,8 @@
 # Reviewing a change to intpot
 
-The procedure. The criteria are in [`AGENTS.md`](../AGENTS.md) — read the **Reviewing a
-change** and **Rules that come from real bugs** sections before you start.
+The procedure. The criteria are in
+[`src/intpot/AGENTS.md`](../src/intpot/AGENTS.md) — read the **Reviewing a change** and
+**Rules that come from real bugs** sections before you start.
 
 This is written for whoever is doing the review: a person, or an agent of any kind. It
 assumes nothing beyond a shell, `git`, and `gh` for the pull-request case.


### PR DESCRIPTION
## Summary
- point the review procedure to `src/intpot/AGENTS.md`, where the required review criteria actually live
- prevent contributors from being sent to sections that do not exist in the root guidance

## Verification
- `make check` — 403 tests passed
- `uv run pytest tests/test_docs.py -q` — 59 tests passed
- `git diff --check`