### PR TITLE
fix: carry dotted imports into generated code

### DIFF
--- a/changelog.d/100.fixed.md
+++ b/changelog.d/100.fixed.md
@@ -1,0 +1,5 @@
+Dotted imports are no longer dropped from generated code. `import os.path` binds `os`,
+but the import scan recorded the binding as `os.path`, so it never matched a body using
+`os.path.join(...)` and the import was omitted — leaving a file that compiled cleanly and
+raised `NameError: name 'os' is not defined` when the command ran. Aliased imports and
+`from x import y` were unaffected.

--- a/changelog.d/100.fixed.md
+++ b/changelog.d/100.fixed.md
@@ -1,5 +1,7 @@
-Dotted imports are no longer dropped from generated code. `import os.path` binds `os`,
-but the import scan recorded the binding as `os.path`, so it never matched a body using
-`os.path.join(...)` and the import was omitted — leaving a file that compiled cleanly and
-raised `NameError: name 'os' is not defined` when the command ran. Aliased imports and
-`from x import y` were unaffected.
+Imports are no longer dropped from generated code. `import os.path` binds `os`, but the
+scan recorded the binding as `os.path`, so it never matched a body using
+`os.path.join(...)`. A statement importing several names was also kept or dropped as a
+whole, so `import os.path, typer` lost `os.path` when the framework import was filtered
+out. Both left a file that compiled cleanly and raised `NameError` when the command ran.
+Imports are now tracked per bound name, and only the names a body actually uses are
+emitted.

--- a/src/intpot/core/inspectors/_utils.py
+++ b/src/intpot/core/inspectors/_utils.py
@@ -40,6 +40,23 @@ def python_return_type_name(annotation: Any) -> str:
     return python_type_name(annotation)
 
 
+def _bound_names(node: ast.Import | ast.ImportFrom) -> set[str]:
+    """The names an import statement actually binds in the module namespace.
+
+    `import os.path` binds `os`, not `os.path` — the body that uses it says
+    `os.path.join(...)`, whose root name is `os`. Recording the dotted path
+    meant the binding never matched anything the body referenced, so the import
+    was dropped and the generated module raised `NameError: name 'os' is not
+    defined` at runtime.
+
+    `import os.path as p` binds `p`, and `from os import path` binds `path`;
+    both are already the full alias name.
+    """
+    if isinstance(node, ast.ImportFrom):
+        return {alias.asname or alias.name for alias in node.names}
+    return {alias.asname or alias.name.split(".", 1)[0] for alias in node.names}
+
+
 def extract_source_imports(fn: Any) -> list[str]:
     """Extract imports from the source file that are referenced in the function body.
 
@@ -64,8 +81,7 @@ def extract_source_imports(fn: Any) -> list[str]:
     import_nodes: list[tuple[ast.stmt, set[str]]] = []
     for node in module_tree.body:
         if isinstance(node, (ast.Import, ast.ImportFrom)):
-            names = {alias.asname or alias.name for alias in node.names}
-            import_nodes.append((node, names))
+            import_nodes.append((node, _bound_names(node)))
 
     if not import_nodes:
         return []

--- a/src/intpot/core/inspectors/_utils.py
+++ b/src/intpot/core/inspectors/_utils.py
@@ -40,8 +40,8 @@ def python_return_type_name(annotation: Any) -> str:
     return python_type_name(annotation)
 
 
-def _bound_names(node: ast.Import | ast.ImportFrom) -> set[str]:
-    """The names an import statement actually binds in the module namespace.
+def _bound_name(node: ast.Import | ast.ImportFrom, alias: ast.alias) -> str:
+    """The name one alias binds in the module namespace.
 
     `import os.path` binds `os`, not `os.path` — the body that uses it says
     `os.path.join(...)`, whose root name is `os`. Recording the dotted path
@@ -52,9 +52,34 @@ def _bound_names(node: ast.Import | ast.ImportFrom) -> set[str]:
     `import os.path as p` binds `p`, and `from os import path` binds `path`;
     both are already the full alias name.
     """
+    if alias.asname:
+        return alias.asname
     if isinstance(node, ast.ImportFrom):
-        return {alias.asname or alias.name for alias in node.names}
-    return {alias.asname or alias.name.split(".", 1)[0] for alias in node.names}
+        return alias.name
+    return alias.name.split(".", 1)[0]
+
+
+def _split_aliases(
+    node: ast.Import | ast.ImportFrom,
+) -> list[tuple[ast.stmt, str]]:
+    """One single-alias statement per name the import binds.
+
+    `import os.path, typer` binds two unrelated names, and downstream filtering
+    works on the rendered *string*: it sees `typer` in it and drops the whole
+    statement, taking `os.path` with it. Splitting first means each name is kept
+    or dropped on its own merit.
+    """
+    split: list[tuple[ast.stmt, str]] = []
+    for alias in node.names:
+        if isinstance(node, ast.ImportFrom):
+            single: ast.stmt = ast.ImportFrom(
+                module=node.module, names=[alias], level=node.level
+            )
+        else:
+            single = ast.Import(names=[alias])
+        ast.copy_location(single, node)
+        split.append((single, _bound_name(node, alias)))
+    return split
 
 
 def extract_source_imports(fn: Any) -> list[str]:
@@ -77,11 +102,12 @@ def extract_source_imports(fn: Any) -> list[str]:
     except (OSError, SyntaxError):
         return []
 
-    # Collect all top-level import nodes and the names they bind
-    import_nodes: list[tuple[ast.stmt, set[str]]] = []
+    # One entry per bound name, so a statement importing several names can be
+    # kept for one and dropped for another.
+    import_nodes: list[tuple[ast.stmt, str]] = []
     for node in module_tree.body:
         if isinstance(node, (ast.Import, ast.ImportFrom)):
-            import_nodes.append((node, _bound_names(node)))
+            import_nodes.extend(_split_aliases(node))
 
     if not import_nodes:
         return []
@@ -108,8 +134,8 @@ def extract_source_imports(fn: Any) -> list[str]:
     # Keep only imports whose bound name appears in body
     result: list[str] = []
     seen: set[str] = set()
-    for node, bound_names in import_nodes:
-        if bound_names & body_names:
+    for node, bound_name in import_nodes:
+        if bound_name in body_names:
             line = ast.unparse(node)
             if line not in seen:
                 seen.add(line)

--- a/tests/test_inspectors/test_utils.py
+++ b/tests/test_inspectors/test_utils.py
@@ -13,7 +13,10 @@ from typing import Any
 from typer.testing import CliRunner
 
 from intpot.core.generators.cli import CLIGenerator
-from intpot.core.inspectors._utils import extract_function_body
+from intpot.core.inspectors._utils import (
+    extract_function_body,
+    extract_source_imports,
+)
 from intpot.core.models import SourceType
 from intpot.core.transforms import transform_tools
 
@@ -116,3 +119,95 @@ def test_the_generated_body_contains_no_nested_definition(tmp_source):
 
     assert body is not None
     assert "def " not in body
+
+
+# ---------------------------------------------------------------------------
+# Import bindings
+#
+# `import os.path` binds `os`, not `os.path`. Recording the dotted path meant
+# the binding never matched what the body referenced, the import was dropped,
+# and the generated module raised NameError at runtime.
+# ---------------------------------------------------------------------------
+
+
+def _imports_for(tmp_source, body_source: str) -> list[str]:
+    path = tmp_source(body_source)
+    return extract_source_imports(_load(path, "tool"))
+
+
+def test_a_dotted_import_is_kept_when_the_body_uses_it(tmp_source):
+    imports = _imports_for(
+        tmp_source,
+        "import os.path\n\n\ndef tool(name: str) -> str:\n"
+        '    return os.path.join("/tmp", name)\n',
+    )
+
+    assert imports == ["import os.path"]
+
+
+def test_a_dotted_import_with_an_alias_binds_the_alias(tmp_source):
+    imports = _imports_for(
+        tmp_source,
+        "import xml.etree.ElementTree as ET\n\n\ndef tool(raw: str) -> str:\n"
+        "    return ET.fromstring(raw).tag\n",
+    )
+
+    assert imports == ["import xml.etree.ElementTree as ET"]
+
+
+def test_from_import_binding_is_unchanged(tmp_source):
+    imports = _imports_for(
+        tmp_source,
+        "from os import path\n\n\ndef tool(name: str) -> str:\n"
+        '    return path.join("/tmp", name)\n',
+    )
+
+    assert imports == ["from os import path"]
+
+
+def test_an_unused_dotted_import_is_still_dropped(tmp_source):
+    """The fix must not turn the filter into "keep everything"."""
+    imports = _imports_for(
+        tmp_source,
+        "import os.path\nimport json\n\n\ndef tool(value: str) -> str:\n"
+        '    return json.dumps({"v": value})\n',
+    )
+
+    assert imports == ["import json"]
+
+
+def test_only_the_first_segment_binds(tmp_source):
+    """`import a.b.c` binds `a`; a body mentioning `b` or `c` must not match."""
+    imports = _imports_for(
+        tmp_source,
+        "import xml.etree.ElementTree\n\n\ndef tool(value: str) -> str:\n"
+        "    return etree(value)\n",
+    )
+
+    assert imports == []
+
+
+def test_a_generated_command_using_a_dotted_import_runs(tmp_source):
+    """The failure was at runtime, so the test has to reach runtime."""
+    path = tmp_source(
+        "import os.path\n"
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("probe")\n'
+        "\n"
+        "@mcp.tool()\n"
+        "def where(name: str) -> str:\n"
+        '    """Join a path."""\n'
+        '    return os.path.join("/tmp", name)\n'
+    )
+
+    from intpot import load
+
+    tools = transform_tools(load(path).tools, SourceType.MCP, SourceType.CLI)
+    namespace: dict[str, Any] = {}
+    exec(compile(CLIGenerator().generate(tools), "<generated>", "exec"), namespace)
+
+    result = CliRunner().invoke(namespace["app"], ["hello"])
+
+    assert result.exit_code == 0, result.output
+    assert "/tmp/hello" in result.output

--- a/tests/test_inspectors/test_utils.py
+++ b/tests/test_inspectors/test_utils.py
@@ -211,3 +211,56 @@ def test_a_generated_command_using_a_dotted_import_runs(tmp_source):
 
     assert result.exit_code == 0, result.output
     assert "/tmp/hello" in result.output
+
+
+def test_a_mixed_import_statement_keeps_the_name_the_body_uses(tmp_source):
+    """`import os.path, typer` binds two unrelated names in one statement.
+
+    Downstream framework filtering works on the rendered string: it saw `typer`
+    and dropped the whole statement, taking `os.path` with it.
+    """
+    imports = _imports_for(
+        tmp_source,
+        "import os.path, typer\n\n\ndef tool(name: str) -> str:\n"
+        '    return os.path.join("/tmp", name)\n',
+    )
+
+    assert imports == ["import os.path"]
+
+
+def test_a_mixed_from_import_keeps_only_the_name_in_use(tmp_source):
+    imports = _imports_for(
+        tmp_source,
+        "from os.path import join, dirname\n\n\ndef tool(name: str) -> str:\n"
+        '    return join("/tmp", name)\n',
+    )
+
+    assert imports == ["from os.path import join"]
+
+
+def test_a_mixed_import_survives_into_a_running_command(tmp_source):
+    """The reviewer's case, end to end: the failure was a runtime NameError."""
+    path = tmp_source(
+        "import os.path, typer\n"
+        "from fastmcp import FastMCP\n"
+        "\n"
+        'mcp = FastMCP("probe")\n'
+        "\n"
+        "@mcp.tool()\n"
+        "def where(name: str) -> str:\n"
+        '    """Join a path."""\n'
+        '    return os.path.join("/tmp", name)\n'
+    )
+
+    from intpot import load
+
+    tools = transform_tools(load(path).tools, SourceType.MCP, SourceType.CLI)
+    source = CLIGenerator().generate(tools)
+    namespace: dict[str, Any] = {}
+    exec(compile(source, "<generated>", "exec"), namespace)
+
+    result = CliRunner().invoke(namespace["app"], ["hello"])
+
+    assert result.exit_code == 0, result.output
+    assert "/tmp/hello" in result.output
+    assert "import os.path" in source


### PR DESCRIPTION
Second in the agreed order, and deliberately before the dependency-closure work since it lands in the same extraction utility.

## The bug

`import os.path` binds **`os`** in the module namespace, not `os.path`. The scan recorded the dotted path as the binding:

```python
names = {alias.asname or alias.name for alias in node.names}   # {"os.path"}
```

A body using it says `os.path.join(...)`, whose root name is `os`. `{"os.path"} & {"os"}` is empty, so the import was dropped:

```python
import typer
import json                 # kept — binds `json`
                            # `import os.path` missing
```

```
$ python out.py where hello
NameError: name 'os' is not defined
```

The generated file imports and compiles cleanly; it fails when the command runs.

## Why it survived this long

The two adjacent forms were always correct:

| form | binds | recorded | |
|---|---|---|---|
| `import os.path` | `os` | `os.path` | ✗ dropped |
| `import os.path as p` | `p` | `p` | ✓ |
| `from os import path` | `path` | `path` | ✓ |

Only the plain dotted form was wrong, and aliased/`from` imports are what most code uses.

## Fix

Bindings are computed per statement type: `ImportFrom` binds the alias name; `Import` binds the alias name, or its first dotted segment when unaliased.

## Tests

Six in `tests/test_inspectors/test_utils.py`:

- dotted import kept when used — the direct regression
- aliased and `from` forms unchanged, so the fix can't quietly alter them
- **an unused dotted import is still dropped** — the filter must not degrade into "keep everything", which is the easy wrong fix here
- `import a.b.c` does not match a body mentioning `b` or `c`, only `a`
- a generated command using a dotted import **runs and produces the right output** — the failure was at runtime, so the test reaches runtime

Two fail on `main`: the direct case and the runtime one. The other four are guards against over-correcting.

`make check`: **416 passed**.
