### PR TITLE
fix: report import failures instead of dumping a traceback

### DIFF
--- a/changelog.d/101.fixed.md
+++ b/changelog.d/101.fixed.md
@@ -1,7 +1,9 @@
 A source that fails to import is now reported instead of crashing. `intpot inspect`,
 `to *`, `eject` and `serve` dumped a full traceback and exited 2 when the source raised
 during import — a missing dependency, an error at module level, or an import of a module
-beside it. They now print what went wrong, name the file, and exit 1. Missing-framework
-hints also stopped guessing: a module merely containing "fastapi" in its name no longer
-advises installing `intpot[api]`. Separately, a tool with a parameter named `_fn` no
-longer breaks `serve --cli`.
+beside it. A source calling `sys.exit()` at import was worse: intpot exited with that
+source's own code and printed nothing, and a directory scan stopped there instead of
+skipping the file. All of these now print what went wrong, name the file, and exit 1.
+Missing-framework hints also stopped guessing: a module merely containing "fastapi" in
+its name no longer advises installing `intpot[api]`. Separately, a tool with a parameter
+named `_fn` no longer breaks `serve --cli`.

--- a/changelog.d/101.fixed.md
+++ b/changelog.d/101.fixed.md
@@ -1,0 +1,7 @@
+A source that fails to import is now reported instead of crashing. `intpot inspect`,
+`to *`, `eject` and `serve` dumped a full traceback and exited 2 when the source raised
+during import — a missing dependency, an error at module level, or an import of a module
+beside it. They now print what went wrong, name the file, and exit 1. Missing-framework
+hints also stopped guessing: a module merely containing "fastapi" in its name no longer
+advises installing `intpot[api]`. Separately, a tool with a parameter named `_fn` no
+longer breaks `serve --cli`.

--- a/changelog.d/101.fixed.md
+++ b/changelog.d/101.fixed.md
@@ -1,9 +1,10 @@
-A source that fails to import is now reported instead of crashing. `intpot inspect`,
-`to *`, `eject` and `serve` dumped a full traceback and exited 2 when the source raised
-during import — a missing dependency, an error at module level, or an import of a module
-beside it. A source calling `sys.exit()` at import was worse: intpot exited with that
-source's own code and printed nothing, and a directory scan stopped there instead of
-skipping the file. All of these now print what went wrong, name the file, and exit 1.
-Missing-framework hints also stopped guessing: a module merely containing "fastapi" in
-its name no longer advises installing `intpot[api]`. Separately, a tool with a parameter
-named `_fn` no longer breaks `serve --cli`.
+A source that cannot be imported or parsed is now reported instead of crashing or
+vanishing. `intpot inspect`, `to *`, `eject` and `serve` dumped a full traceback and
+exited 2 when the source raised during import; a source calling `sys.exit()` at import
+made intpot exit with that source's own code and print nothing, and stopped a directory
+scan dead; and a file with a syntax error was reported as simply having no app in it,
+indistinguishable from a valid module, and skipped silently during a scan. All of these
+now say what went wrong, name the file, and exit 1, while a scan reports the bad file and
+converts the rest. Missing-framework hints also stopped guessing: a module merely
+containing "fastapi" in its name no longer advises installing `intpot[api]`. Separately, a
+tool with a parameter named `_fn` no longer breaks `serve --cli`.

--- a/src/intpot/commands/serve.py
+++ b/src/intpot/commands/serve.py
@@ -7,14 +7,19 @@ from pathlib import Path
 
 import typer
 
-from intpot.core.detector import _import_module_from_path
+from intpot.core.detector import DetectionError, _import_module_from_path
 
 
 def _find_intpot_app(source_path: Path) -> object:
     """Import a module and find the intpot App instance."""
     from intpot.runtime import App
 
-    module = _import_module_from_path(source_path)
+    try:
+        module = _import_module_from_path(source_path)
+    except DetectionError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from exc
+
     for attr_name in dir(module):
         if attr_name.startswith("_"):
             continue

--- a/src/intpot/converter.py
+++ b/src/intpot/converter.py
@@ -6,7 +6,7 @@ import functools
 from pathlib import Path
 from typing import Any
 
-from intpot.core.detector import detect_instance, detect_source
+from intpot.core.detector import SourceImportError, detect_instance, detect_source
 from intpot.core.models import SourceType, ToolInfo
 
 
@@ -102,6 +102,29 @@ class IntpotApp:
         return out.resolve()
 
 
+def _missing_module_error(exc: ModuleNotFoundError) -> ModuleNotFoundError:
+    """Point at the right extra, or hand the original error back unchanged.
+
+    The top-level module is matched exactly. `"fastapi" in module` also matched
+    a user's own missing `myfastapi_helper`, sending them to install
+    intpot[api] — which would not have helped and hid the real cause.
+    """
+    top_level = (exc.name or "").split(".", 1)[0]
+    if top_level == "fastmcp":
+        return ModuleNotFoundError(
+            "FastMCP is required for MCP support. "
+            "Install it with: pip install intpot[mcp]",
+            name=exc.name,
+        )
+    if top_level in ("fastapi", "uvicorn"):
+        return ModuleNotFoundError(
+            "FastAPI is required for API support. "
+            "Install it with: pip install intpot[api]",
+            name=exc.name,
+        )
+    return exc
+
+
 def load(source: Any) -> IntpotApp:
     """Load a source for conversion.
 
@@ -124,19 +147,14 @@ def load(source: Any) -> IntpotApp:
 
         source_type, app_instance = detect_instance(source)
         return IntpotApp(source_type, app_instance)
-    except ModuleNotFoundError as e:
-        # Match the top-level module exactly. `"fastapi" in module` also matched
-        # a user's own missing `myfastapi_helper`, sending them to install
-        # intpot[api] — which would not have helped and hid the real cause.
-        top_level = (e.name or "").split(".", 1)[0]
-        if top_level == "fastmcp":
-            raise ModuleNotFoundError(
-                "FastMCP is required for MCP support. "
-                "Install it with: pip install intpot[mcp]"
-            ) from e
-        if top_level in ("fastapi", "uvicorn"):
-            raise ModuleNotFoundError(
-                "FastAPI is required for API support. "
-                "Install it with: pip install intpot[api]"
-            ) from e
+    except SourceImportError as e:
+        # detect_source wraps whatever the user's module raised so the CLI can
+        # report it. This is the Python API, which documents ModuleNotFoundError
+        # — unwrap it back so callers catching that keep working.
+        if isinstance(e.__cause__, ModuleNotFoundError):
+            raise _missing_module_error(e.__cause__) from e
         raise
+    except ModuleNotFoundError as e:
+        # The live-instance path: inspectors import fastmcp/fastapi themselves,
+        # and that never goes through detect_source.
+        raise _missing_module_error(e) from e

--- a/src/intpot/converter.py
+++ b/src/intpot/converter.py
@@ -151,8 +151,16 @@ def load(source: Any) -> IntpotApp:
         # detect_source wraps whatever the user's module raised so the CLI can
         # report it. This is the Python API, which documents ModuleNotFoundError
         # — unwrap it back so callers catching that keep working.
-        if isinstance(e.__cause__, ModuleNotFoundError):
-            raise _missing_module_error(e.__cause__) from e
+        original = e.__cause__
+        if isinstance(original, ModuleNotFoundError):
+            mapped = _missing_module_error(original)
+            if mapped is original:
+                # Handing the original back means exactly that. `raise original
+                # from e` would set original.__cause__ = e while e.__cause__ is
+                # already original, so the chain points at itself and anything
+                # walking __cause__ loops forever.
+                raise mapped from None
+            raise mapped from original
         raise
     except ModuleNotFoundError as e:
         # The live-instance path: inspectors import fastmcp/fastapi themselves,

--- a/src/intpot/converter.py
+++ b/src/intpot/converter.py
@@ -125,13 +125,16 @@ def load(source: Any) -> IntpotApp:
         source_type, app_instance = detect_instance(source)
         return IntpotApp(source_type, app_instance)
     except ModuleNotFoundError as e:
-        module = e.name or ""
-        if "fastmcp" in module:
+        # Match the top-level module exactly. `"fastapi" in module` also matched
+        # a user's own missing `myfastapi_helper`, sending them to install
+        # intpot[api] — which would not have helped and hid the real cause.
+        top_level = (e.name or "").split(".", 1)[0]
+        if top_level == "fastmcp":
             raise ModuleNotFoundError(
                 "FastMCP is required for MCP support. "
                 "Install it with: pip install intpot[mcp]"
             ) from e
-        if "fastapi" in module:
+        if top_level in ("fastapi", "uvicorn"):
             raise ModuleNotFoundError(
                 "FastAPI is required for API support. "
                 "Install it with: pip install intpot[api]"

--- a/src/intpot/core/detector.py
+++ b/src/intpot/core/detector.py
@@ -31,8 +31,14 @@ class SourceImportError(DetectionError):
 _EXTRA_FOR_MODULE = {"fastmcp": "mcp", "fastapi": "api", "uvicorn": "api"}
 
 
-def _import_failure_message(source_path: Path, exc: Exception) -> str:
+def _import_failure_message(source_path: Path, exc: BaseException) -> str:
     """Explain an import failure in terms the user can act on."""
+    if isinstance(exc, SystemExit):
+        return (
+            f"Cannot import {source_path}: it called sys.exit({exc.code!r}) while "
+            f"being imported. Detection has to import the file, so module-level "
+            f"exits run too — guard them with `if __name__ == '__main__':`."
+        )
     detail = f"Cannot import {source_path}: {type(exc).__name__}: {exc}"
     missing = (
         getattr(exc, "name", None) if isinstance(exc, ModuleNotFoundError) else None
@@ -93,9 +99,15 @@ def _import_module_from_path(source_path: Path) -> Any:
     sys.modules[unique_name] = module
     try:
         spec.loader.exec_module(module)
-    except Exception as exc:
+    except (Exception, SystemExit) as exc:
         # The user's own module raised. Every command funnels through here, so
         # wrapping once is what stops a traceback reaching the terminal.
+        #
+        # SystemExit is listed separately because it derives from BaseException,
+        # not Exception: a source calling sys.exit() at import — argparse on a
+        # bad parse does exactly this — otherwise propagated, and intpot exited
+        # with the source's own code and printed nothing at all. Catching
+        # BaseException instead would also swallow KeyboardInterrupt.
         raise SourceImportError(_import_failure_message(source_path, exc)) from exc
     finally:
         # Clean up sys.modules to avoid leaking imported modules

--- a/src/intpot/core/detector.py
+++ b/src/intpot/core/detector.py
@@ -67,8 +67,15 @@ def _has_framework_app_ast(source_path: Path) -> bool:
     try:
         source = source_path.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(source_path))
-    except (SyntaxError, UnicodeDecodeError, ValueError):
-        return False
+    except (SyntaxError, UnicodeDecodeError, ValueError) as exc:
+        # Returning False here reported malformed Python as "no app instance
+        # found" — the same message a perfectly valid non-app file gets — and a
+        # directory scan skipped it without a word. A file that cannot be parsed
+        # is broken, not uninteresting, and the user is the only one who can
+        # fix it.
+        raise SourceImportError(
+            f"Cannot parse {source_path}: {type(exc).__name__}: {exc}"
+        ) from exc
 
     for node in ast.iter_child_nodes(tree):
         if not isinstance(node, (ast.Assign, ast.AnnAssign)):

--- a/src/intpot/core/detector.py
+++ b/src/intpot/core/detector.py
@@ -17,6 +17,40 @@ class DetectionError(Exception):
     pass
 
 
+class SourceImportError(DetectionError):
+    """The source file was found and looked like an app, but importing it failed.
+
+    Distinct from "this file is not an app": the user's own module raised.
+    Subclassing DetectionError means every command that already handles a
+    detection failure reports this cleanly instead of dumping a traceback —
+    but anything that needs to tell the two apart must catch this *first*,
+    since a subclass matches its parent.
+    """
+
+
+_EXTRA_FOR_MODULE = {"fastmcp": "mcp", "fastapi": "api", "uvicorn": "api"}
+
+
+def _import_failure_message(source_path: Path, exc: Exception) -> str:
+    """Explain an import failure in terms the user can act on."""
+    detail = f"Cannot import {source_path}: {type(exc).__name__}: {exc}"
+    missing = (
+        getattr(exc, "name", None) if isinstance(exc, ModuleNotFoundError) else None
+    )
+    # Match the top-level module exactly. Substring matching claimed a missing
+    # `myfastapi_helper` was FastAPI and sent the user to install intpot[api],
+    # which would not have helped and hid the real cause.
+    extra = _EXTRA_FOR_MODULE.get((missing or "").split(".", 1)[0])
+    if extra:
+        return f"{detail}\nInstall it with: pip install intpot[{extra}]"
+    if missing:
+        return (
+            f"{detail}\nIf it is a module beside your source, intpot imports the "
+            f"file directly and does not add its directory to sys.path."
+        )
+    return detail
+
+
 def _has_framework_app_ast(source_path: Path) -> bool:
     """Check if a Python file contains a framework app assignment using AST.
 
@@ -59,6 +93,10 @@ def _import_module_from_path(source_path: Path) -> Any:
     sys.modules[unique_name] = module
     try:
         spec.loader.exec_module(module)
+    except Exception as exc:
+        # The user's own module raised. Every command funnels through here, so
+        # wrapping once is what stops a traceback reaching the terminal.
+        raise SourceImportError(_import_failure_message(source_path, exc)) from exc
     finally:
         # Clean up sys.modules to avoid leaking imported modules
         sys.modules.pop(unique_name, None)

--- a/src/intpot/core/discovery.py
+++ b/src/intpot/core/discovery.py
@@ -50,7 +50,8 @@ def discover_sources(
         except SourceImportError as exc:
             # Must precede DetectionError: SourceImportError subclasses it, and
             # matching the parent first would silence import failures again (#59).
-            print(f"SKIP (import failed): {py_file}: {exc}", file=sys.stderr)
+            # The exception already names the file and the problem.
+            print(f"SKIP (import failed): {exc}", file=sys.stderr)
             continue
         except DetectionError:
             # Ordinary: most files in a project are not framework apps.

--- a/src/intpot/core/discovery.py
+++ b/src/intpot/core/discovery.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from intpot.core.detector import DetectionError, detect_source
+from intpot.core.detector import DetectionError, SourceImportError, detect_source
 from intpot.core.models import SourceType
 
 _SKIP_DIRS = {
@@ -47,6 +47,11 @@ def discover_sources(
 
         try:
             source_type, app_instance = detect_source(py_file)
+        except SourceImportError as exc:
+            # Must precede DetectionError: SourceImportError subclasses it, and
+            # matching the parent first would silence import failures again (#59).
+            print(f"SKIP (import failed): {py_file}: {exc}", file=sys.stderr)
+            continue
         except DetectionError:
             # Ordinary: most files in a project are not framework apps.
             if verbose:

--- a/src/intpot/runtime_builders.py
+++ b/src/intpot/runtime_builders.py
@@ -77,21 +77,29 @@ def build_typer_app(name: str, tools: list[RegisteredTool]) -> _typer.Typer:
 
     import typer
 
-    cli_app = typer.Typer(name=name, help=f"{name} — powered by intpot")
-    for tool in tools:
-        # Wrap so return values are printed — plain functions return values,
-        # but Typer commands need explicit output via typer.echo().
-        fn = _restore_positional_only(tool.func)
+    def _echoing(fn: Callable[..., Any]) -> Callable[..., None]:
+        """Print what the tool returns; Typer discards return values.
+
+        `fn` is bound by closure rather than as a default argument. As a
+        default it sat in the wrapper's own signature, so a tool with a
+        parameter of that name overrode it and the wrapper tried to call the
+        user's value: `TypeError: 'str' object is not callable`.
+        """
 
         @functools.wraps(fn)
-        def _cli_wrapper(*args: object, _fn: object = fn, **kwargs: object) -> None:
-            result = _fn(*args, **kwargs)  # type: ignore[operator]
+        def _cli_wrapper(*args: object, **kwargs: object) -> None:
+            result = fn(*args, **kwargs)
             if inspect.iscoroutine(result):
                 result = asyncio.run(result)
             if result is not None:
                 typer.echo(result)
 
-        cli_app.command(name=tool.info.name, help=tool.info.description)(_cli_wrapper)
+        return _cli_wrapper
+
+    cli_app = typer.Typer(name=name, help=f"{name} — powered by intpot")
+    for tool in tools:
+        wrapped = _echoing(_restore_positional_only(tool.func))
+        cli_app.command(name=tool.info.name, help=tool.info.description)(wrapped)
     return cli_app
 
 

--- a/tests/test_import_failures.py
+++ b/tests/test_import_failures.py
@@ -295,3 +295,49 @@ def test_load_still_raises_a_detection_error_for_a_non_app(tmp_source):
 
     with pytest.raises(DetectionError):
         load(tmp_source("value = 42\n"))
+
+
+def _cause_chain(exc: BaseException) -> tuple[list[str], bool]:
+    """Walk __cause__ defensively, reporting whether it loops."""
+    seen: set[int] = set()
+    node: BaseException | None = exc
+    names: list[str] = []
+    while node is not None and id(node) not in seen:
+        seen.add(id(node))
+        names.append(type(node).__name__)
+        node = node.__cause__
+    return names, node is not None
+
+
+def test_load_does_not_build_a_circular_cause_chain(tmp_source):
+    """`raise original from e` when e.__cause__ is already original loops.
+
+    The helper-level identity test cannot see this: the cycle is created by the
+    raise, not by the mapping. Anything walking __cause__ — a logger, a
+    debugger, Sentry — would spin.
+    """
+    from intpot import load
+
+    source = tmp_source(
+        "import totally_absent_module\n"
+        "from fastmcp import FastMCP\n"
+        'mcp = FastMCP("probe")\n'
+    )
+
+    with pytest.raises(ModuleNotFoundError) as caught:
+        load(source)
+
+    names, cyclic = _cause_chain(caught.value)
+    assert not cyclic, f"cause chain loops: {names}"
+    assert caught.value.__cause__ is not caught.value
+
+
+def test_load_keeps_the_original_missing_module_reachable(tmp_source):
+    """A newly mapped framework error must still chain to what actually failed."""
+    from intpot.converter import _missing_module_error
+
+    original = ModuleNotFoundError("No module named 'fastmcp'", name="fastmcp")
+    mapped = _missing_module_error(original)
+
+    assert mapped is not original
+    assert mapped.name == "fastmcp"

--- a/tests/test_import_failures.py
+++ b/tests/test_import_failures.py
@@ -175,3 +175,123 @@ def test_directory_scan_stays_quiet_about_files_that_are_not_apps(tmp_path: Path
 
     assert result.exit_code == 0, result.output
     assert "SKIP (import failed)" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# sys.exit() during import
+#
+# SystemExit derives from BaseException, not Exception, so `except Exception`
+# never saw it. intpot exited with the *source's* code and printed nothing —
+# and a directory scan terminated instead of skipping the file and continuing.
+# argparse calls sys.exit() on a bad parse, so this is reachable by accident.
+# ---------------------------------------------------------------------------
+
+_EXITS_ON_IMPORT = """\
+import sys
+from fastmcp import FastMCP
+
+mcp = FastMCP("probe")
+sys.exit(3)
+"""
+
+
+def test_a_source_that_exits_during_import_is_reported(tmp_source):
+    source = tmp_source(_EXITS_ON_IMPORT)
+
+    result = runner.invoke(app, ["inspect", str(source)])
+
+    assert result.exit_code == 1, (
+        f"inherited the source's exit code: {result.exit_code}"
+    )
+    assert "sys.exit(3)" in result.output
+    assert "__main__" in result.output, "no guidance on how to avoid it"
+
+
+def test_a_directory_scan_survives_a_source_that_exits(tmp_path: Path):
+    """The scan must skip the file and keep going, not abort at exit code 3."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "exiter.py").write_text(_EXITS_ON_IMPORT)
+    (project / "server.py").write_text(
+        textwrap.dedent("""\
+            from fastmcp import FastMCP
+            mcp = FastMCP("probe")
+
+            @mcp.tool()
+            def echo(value: str) -> str:
+                "Echo."
+                return value
+            """)
+    )
+    out = tmp_path / "out"
+
+    result = runner.invoke(app, ["to", "cli", str(project), "-o", str(out)])
+
+    assert result.exit_code == 0, result.output
+    assert "SKIP (import failed)" in result.output
+    assert (out / "server_cli.py").exists(), "the good file was not converted"
+
+
+def test_keyboard_interrupt_is_not_swallowed(tmp_source, monkeypatch):
+    """Catching BaseException would trap Ctrl-C too; only SystemExit is caught."""
+    from intpot.core import detector
+
+    source = tmp_source('from fastmcp import FastMCP\nmcp = FastMCP("probe")\n')
+
+    def _interrupt(self, module):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        "importlib.machinery.SourceFileLoader.exec_module", _interrupt, raising=False
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        detector.detect_source(source)
+
+
+# ---------------------------------------------------------------------------
+# The documented Python-API contract
+# ---------------------------------------------------------------------------
+
+
+def test_load_still_raises_module_not_found_for_a_path(tmp_source):
+    """`load()` documents ModuleNotFoundError; wrapping made it unreachable."""
+    from intpot import load
+
+    source = tmp_source(
+        "import totally_absent_module\n"
+        "from fastmcp import FastMCP\n"
+        'mcp = FastMCP("probe")\n'
+    )
+
+    with pytest.raises(ModuleNotFoundError) as caught:
+        load(source)
+
+    assert "totally_absent_module" in str(caught.value)
+    assert caught.value.name == "totally_absent_module"
+
+
+def test_load_keeps_the_install_hint_for_a_missing_extra():
+    from intpot.converter import _missing_module_error
+
+    hinted = _missing_module_error(ModuleNotFoundError(name="fastmcp"))
+
+    assert "intpot[mcp]" in str(hinted)
+    assert hinted.name == "fastmcp"
+
+
+def test_load_hands_back_an_unrelated_missing_module_unchanged():
+    from intpot.converter import _missing_module_error
+
+    original = ModuleNotFoundError(
+        "No module named 'myfastapi_helper'", name="myfastapi_helper"
+    )
+
+    assert _missing_module_error(original) is original
+
+
+def test_load_still_raises_a_detection_error_for_a_non_app(tmp_source):
+    from intpot import load
+
+    with pytest.raises(DetectionError):
+        load(tmp_source("value = 42\n"))

--- a/tests/test_import_failures.py
+++ b/tests/test_import_failures.py
@@ -341,3 +341,85 @@ def test_load_keeps_the_original_missing_module_reachable(tmp_source):
 
     assert mapped is not original
     assert mapped.name == "fastmcp"
+
+
+# ---------------------------------------------------------------------------
+# Malformed Python
+#
+# The AST pre-check swallowed SyntaxError and returned False, so a file that
+# does not parse got the same message as a valid file with no app in it — and a
+# directory scan dropped it without a word. Broken is not the same as
+# uninteresting, and only the user can fix it.
+# ---------------------------------------------------------------------------
+
+_MALFORMED = 'from fastmcp import FastMCP\nmcp = FastMCP("d"\n\ndef broken(:\n'
+
+
+def test_a_malformed_source_reports_the_parse_error(tmp_source):
+    source = tmp_source(_MALFORMED)
+
+    result = runner.invoke(app, ["inspect", str(source)])
+
+    assert result.exit_code == 1, result.output
+    assert "Cannot parse" in result.output
+    assert "SyntaxError" in result.output
+    assert "No FastMCP, Typer, or FastAPI app instance found" not in result.output
+
+
+def test_a_valid_file_with_no_app_is_still_reported_as_having_no_app(tmp_source):
+    """The two must stay distinguishable — that is the whole point."""
+    result = runner.invoke(app, ["inspect", str(tmp_source("value = 42\n"))])
+
+    assert result.exit_code == 1
+    assert "No FastMCP, Typer, or FastAPI app instance found" in result.output
+    assert "Cannot parse" not in result.output
+
+
+def test_a_directory_scan_reports_a_malformed_file_and_continues(tmp_path: Path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "malformed.py").write_text(_MALFORMED)
+    (project / "good.py").write_text(
+        textwrap.dedent("""\
+            from fastmcp import FastMCP
+            mcp = FastMCP("probe")
+
+            @mcp.tool()
+            def echo(value: str) -> str:
+                "Echo."
+                return value
+            """)
+    )
+    out = tmp_path / "out"
+
+    result = runner.invoke(app, ["to", "cli", str(project), "-o", str(out)])
+
+    assert result.exit_code == 0, result.output
+    assert "SKIP (import failed)" in result.output
+    assert "Cannot parse" in result.output
+    assert (out / "good_cli.py").exists(), "the good file was not converted"
+
+
+def test_a_directory_scan_stays_quiet_about_valid_non_app_files(tmp_path: Path):
+    """Reporting parse failures must not make ordinary modules noisy."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "helpers.py").write_text("VALUE = 42\n")
+    (project / "good.py").write_text(
+        textwrap.dedent("""\
+            from fastmcp import FastMCP
+            mcp = FastMCP("probe")
+
+            @mcp.tool()
+            def echo(value: str) -> str:
+                "Echo."
+                return value
+            """)
+    )
+
+    result = runner.invoke(
+        app, ["to", "cli", str(project), "-o", str(tmp_path / "out")]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "SKIP" not in result.output

--- a/tests/test_import_failures.py
+++ b/tests/test_import_failures.py
@@ -1,0 +1,177 @@
+"""A source that fails to import must be reported, not dumped as a traceback.
+
+Detection executes the user's module, so anything it raises reaches intpot.
+Only DetectionError was caught, so a missing dependency, a module-level error
+or an unresolvable sibling import produced a full rich traceback and Typer's
+crash exit code. Directory scanning already handled this; single-file commands,
+which is what most people run, did not.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from intpot.cli import app
+from intpot.core.detector import DetectionError, SourceImportError, detect_source
+
+runner = CliRunner()
+
+_RAISES_ON_IMPORT = """\
+import nonexistent_module_xyz
+from fastmcp import FastMCP
+
+mcp = FastMCP("probe")
+
+@mcp.tool()
+def echo(value: str) -> str:
+    "Echo."
+    return value
+"""
+
+
+@pytest.fixture()
+def broken_source(tmp_source) -> Path:
+    return tmp_source(_RAISES_ON_IMPORT)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        pytest.param(["inspect"], id="inspect"),
+        pytest.param(["to", "cli"], id="to-cli"),
+        pytest.param(["to", "mcp"], id="to-mcp"),
+        pytest.param(["to", "api"], id="to-api"),
+    ],
+)
+def test_commands_report_an_import_failure_without_a_traceback(argv, broken_source):
+    result = runner.invoke(app, [*argv, str(broken_source)])
+
+    assert result.exit_code == 1, result.output
+    assert "Cannot import" in result.output
+    assert "nonexistent_module_xyz" in result.output
+    assert "Traceback" not in result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_eject_reports_an_import_failure_without_a_traceback(broken_source):
+    result = runner.invoke(app, ["eject", str(broken_source), "--to", "cli"])
+
+    assert result.exit_code == 1, result.output
+    assert "Cannot import" in result.output
+
+
+def test_serve_reports_an_import_failure_without_a_traceback(broken_source):
+    result = runner.invoke(app, ["serve", str(broken_source), "--cli"])
+
+    assert result.exit_code == 1, result.output
+    assert "Cannot import" in result.output
+
+
+def test_the_error_names_the_file_and_the_original_exception(broken_source):
+    with pytest.raises(SourceImportError) as caught:
+        detect_source(broken_source)
+
+    message = str(caught.value)
+    assert str(broken_source) in message
+    assert "ModuleNotFoundError" in message
+    assert "nonexistent_module_xyz" in message
+    assert caught.value.__cause__ is not None, "original exception discarded"
+
+
+def test_a_source_import_error_is_a_detection_error() -> None:
+    """Subclassing is what makes every existing handler report it cleanly."""
+    assert issubclass(SourceImportError, DetectionError)
+
+
+# ---------------------------------------------------------------------------
+# Install hints must name the right package
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("missing", "expected"),
+    [
+        ("fastmcp", "intpot[mcp]"),
+        ("fastapi", "intpot[api]"),
+        ("uvicorn", "intpot[api]"),
+    ],
+)
+def test_a_missing_framework_points_at_the_right_extra(missing, expected):
+    from intpot.core.detector import _import_failure_message
+
+    message = _import_failure_message(Path("app.py"), ModuleNotFoundError(name=missing))
+
+    assert expected in message
+
+
+def test_a_users_own_module_is_not_mistaken_for_a_framework():
+    """`"fastapi" in "myfastapi_helper"` sent people to install intpot[api].
+
+    It would not have helped, and it hid the real cause.
+    """
+    from intpot.core.detector import _import_failure_message
+
+    message = _import_failure_message(
+        Path("app.py"), ModuleNotFoundError(name="myfastapi_helper")
+    )
+
+    assert "intpot[api]" not in message
+    assert "myfastapi_helper" not in message or "sys.path" in message
+
+
+def test_a_missing_sibling_module_explains_why(tmp_source):
+    source = tmp_source(
+        "from helpers import double\n"
+        "from fastmcp import FastMCP\n"
+        'mcp = FastMCP("probe")\n'
+    )
+
+    result = runner.invoke(app, ["inspect", str(source)])
+
+    assert result.exit_code == 1
+    assert "sys.path" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Directory scanning must keep telling the two cases apart (#59)
+# ---------------------------------------------------------------------------
+
+
+def test_directory_scan_still_reports_import_failures(tmp_path: Path):
+    """SourceImportError subclasses DetectionError, so ordering matters here."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "broken.py").write_text(_RAISES_ON_IMPORT)
+
+    result = runner.invoke(app, ["to", "cli", str(project)])
+
+    assert "SKIP (import failed)" in result.output
+    assert "nonexistent_module_xyz" in result.output
+
+
+def test_directory_scan_stays_quiet_about_files_that_are_not_apps(tmp_path: Path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "plain.py").write_text("value = 42\n")
+    (project / "server.py").write_text(
+        textwrap.dedent("""\
+            from fastmcp import FastMCP
+            mcp = FastMCP("probe")
+
+            @mcp.tool()
+            def echo(value: str) -> str:
+                "Echo."
+                return value
+            """)
+    )
+
+    result = runner.invoke(
+        app, ["to", "cli", str(project), "-o", str(tmp_path / "out")]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "SKIP (import failed)" not in result.output

--- a/tests/test_runtime_builders.py
+++ b/tests/test_runtime_builders.py
@@ -332,3 +332,27 @@ def test_build_typer_app_runs_async_tool():
 
     assert result.exit_code == 0
     assert "Hello, World!" in result.output
+
+
+def test_a_parameter_named_like_the_wrapper_internal_still_works():
+    """`_fn` was the wrapper's own default argument, so Typer overrode it.
+
+    The wrapper then called the user's value: `'str' object is not callable`.
+    Binding by closure keeps the wrapper's signature to the tool's parameters.
+    """
+    from typer.testing import CliRunner
+
+    from intpot import App
+    from intpot.runtime_builders import build_typer_app
+
+    app = App("collision")
+
+    @app.tool()
+    def pick(_fn: str) -> str:
+        """A parameter that shadowed the wrapper's own."""
+        return f"got {_fn}"
+
+    result = CliRunner().invoke(build_typer_app("collision", app._tools), ["hello"])
+
+    assert result.exit_code == 0, result.exception or result.output
+    assert "got hello" in result.output


### PR DESCRIPTION
Findings from the codebase review, plus three rounds of review on this PR. Everything reproduced before being fixed.

The theme is one question: **what happens when a source can't be used?** Every answer was wrong in a different way.

## 1. Import failures dumped a traceback

`detect_source` executes the user's module. Only `DetectionError` was caught, so anything else propagated:

```
│ ❱ 1 import nonexistent_module_xyz                    │
╰─────────────────────────────────────────────────────╯
ModuleNotFoundError: No module named 'nonexistent_module_xyz'
```

`inspect`, `to *`, `eject` and `serve` all did this, exiting **2** (Typer's crash code). Directory scanning handled the identical file correctly, so the two paths disagreed — and the one people use most was the broken one.

**Fix.** Every command funnels through `_import_module_from_path`, so the wrap goes there. `SourceImportError` **subclasses** `DetectionError`, so each command's existing handler reports it cleanly with no per-command change.

That subclassing has a sharp edge, documented on the class and covered by tests in both directions: `discovery.py` must catch `SourceImportError` **before** `DetectionError`, or an import failure matches the parent, looks like "not an app", and goes silent — undoing #59.

## 2. `sys.exit()` at import was worse than a traceback

`SystemExit` derives from `BaseException`, so `except Exception` never saw it. The source's exit code became **intpot's**, with no output at all:

```
$ intpot inspect exiter.py     # module calls sys.exit(3)
$ echo $?
3
```

The directory scan did the same — exit 3, run over. `argparse.parse_args()` hits this on a bad parse.

Caught explicitly alongside `Exception` rather than widening to `BaseException`; a test asserts Ctrl-C still propagates.

## 3. Malformed Python was reported as "no app here"

`_has_framework_app_ast` swallowed `SyntaxError` and returned `False`, so a file that doesn't parse got the same message as a valid module containing no app — and a scan dropped it silently. Broken is not the same as uninteresting.

Parse failures now raise `SourceImportError` too, reusing the handling above. Valid non-app files stay quiet, in both single-file and directory form, with tests for each.

## 4. Install hints named the wrong package

`"fastapi" in module` matched a user's own missing `myfastapi_helper` and sent them to install `intpot[api]` — which wouldn't help and hid the real cause. Top-level name matched exactly now.

## 5. `load()`'s documented contract broke

Wrapping made `except ModuleNotFoundError` unreachable for path sources, contradicting `load()`'s own docstring. It now unwraps a `SourceImportError` caused by a `ModuleNotFoundError` and re-raises that, preserving `.name`.

`load()` **raises** — it's the Python API. The CLI commands exit 1; `load()` does not.

## 6. The unwrap created a circular cause chain

Introduced while fixing 5, caught in review:

```
exc.__cause__.__cause__ is exc  →  True
```

`raise original from e` set `original.__cause__ = e` while `e.__cause__` was already `original`. Anything walking the chain loops. Branch on identity now: an unchanged original is re-raised `from None`; a newly mapped error chains from what actually failed.

## 7. A tool parameter named `_fn` broke `serve --cli`

`build_typer_app` bound the tool as a default argument, putting it in the wrapper's own signature. Typer passed the user's `_fn="hello"` and the wrapper called a string. Bound by closure now.

## Tests

**35** in `tests/test_import_failures.py` plus one in `test_runtime_builders.py`.

Beyond the direct regressions, the ones that matter most are the ones asserting things *keep* working:

- valid non-app files stay quiet, single-file **and** in a scan
- a scan reports the bad file **and still converts the good one** — that assertion is what proves it continued, rather than merely not crashing
- `KeyboardInterrupt` still propagates
- the cause chain is walked with a seen-set, failing on a repeat rather than hanging

Verification note: these can't be run against `main` to show a red-to-green count, because they import a symbol that doesn't exist there. Individual fixes were each confirmed by reverting the relevant source file — 2 fail without the parse fix, 5 without the `SystemExit` and contract fixes, 1 without the cycle fix.

`make check`: **448 passed**.
