### PR TITLE
docs: record what the error-path bugs taught

### DIFF
--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -83,6 +83,19 @@ Don't raise anything you can't back with evidence. Four of the bugs this project
 shipped looked correct as text; if a claim is about generated code, run the generated
 code.
 
+**Then check that your check could have failed.** A verification that cannot detect the
+problem reports success just as confidently as one that can, and this has produced two
+false "all clear" results here:
+
+- grepping command output for `Traceback` to prove no traceback leaked — Typer renders
+  them through rich, as a box that never contains that word. Four commands were reported
+  clean while all four were dumping tracebacks.
+- reading `$?` after a shell pipeline rather than the command, which reports the exit
+  status of `tail`.
+
+Before trusting a negative result, break the thing on purpose and confirm the check goes
+red. If it doesn't, you have learned nothing about the code — only about the check.
+
 ## 6. Report
 
 Classify:

--- a/src/intpot/AGENTS.md
+++ b/src/intpot/AGENTS.md
@@ -42,6 +42,14 @@ identifier produced a duplicate argument. Never hand-write quotes around interpo
 text — use the `repr` filter, which is Python's own literal writer. Tests must `compile()`
 the output, not inspect it.
 
+**Error paths need their own probes.** Exercising the happy path never reaches them, so
+they are where this codebase's bugs survive longest. #101 took three review rounds and
+every finding was in an `except` branch: `SystemExit` slipping past `except Exception`, a
+documented exception a wrapper had made unreachable, and a cause chain pointing at
+itself. When you touch error handling, enumerate what can actually be raised and run each
+one — a source that exits, a source that raises, a missing dependency, a missing sibling
+module — rather than reasoning about them.
+
 **A guard that can collect nothing must assert it found something.** The test asserting
 every CLI flag appears in the README derives its cases by walking the command tree. When
 that walk broke, the test quietly went from 22 assertions to 1 and kept reporting green —
@@ -99,6 +107,25 @@ the contracts a change has to keep.
 - `discover_sources()` stays quiet about files that simply aren't apps (verbose only),
   but always reports an import failure to stderr. A scan has to survive one bad file
   without going silent about it (#59).
+- **`except Exception` does not catch everything.** `SystemExit` and `KeyboardInterrupt`
+  derive from `BaseException`. A source calling `sys.exit()` at import — which
+  `argparse.parse_args()` does on a bad parse — went straight through detection: intpot
+  exited with *that source's* code and printed nothing, and a directory scan stopped
+  there. Catch `SystemExit` explicitly alongside `Exception`; widening to `BaseException`
+  instead would swallow Ctrl-C.
+- **An exception subclass rewires every `except` for its parent.** Subclassing
+  `DetectionError` is how a new failure kind reaches existing handlers unchanged — and
+  also how it reaches the ones that should have treated it differently. Any site that
+  tells the two apart has to catch the subclass *first*, or the parent matches and the
+  distinction silently disappears. Adding a subclass means auditing every existing
+  handler for the parent, `discover_sources()` above being the one that matters.
+- **`raise X from Y` mutates X.** It sets `X.__cause__ = Y`. When `Y.__cause__` is
+  already `X` — which it is whenever you unwrap and re-raise — the chain points at itself
+  and anything walking it loops. Re-raise an untouched original `from None`; chain a
+  newly built error from what actually failed.
+- **Wrapping an exception can break a documented contract.** `load()` documents that it
+  raises `ModuleNotFoundError`; wrapping import failures made its own handler
+  unreachable. Check `Raises:` docstrings and callers before introducing a wrapper.
 
 **Tests**
 


### PR DESCRIPTION
#101 took three review rounds. Every finding was in an `except` branch, and nothing in the existing guidance would have prevented any of them.

## `src/intpot/AGENTS.md`

**One new rule under "Rules that come from real bugs":** error paths need their own probes. Exercising the happy path never reaches them, which is why bugs survive there longest. The fix is procedural — enumerate what can actually be raised and *run* each one rather than reasoning about them.

**Four criteria under Errors**, each from a specific finding:

| | |
|---|---|
| `except Exception` misses `SystemExit` | A source calling `sys.exit()` at import escaped detection: intpot exited with **that source's** code and printed nothing, and a directory scan stopped there. `argparse.parse_args()` does this on a bad parse. Widening to `BaseException` would swallow Ctrl-C. |
| A subclass rewires every parent handler | Nearly undid #59 — import failures matching `except DetectionError` would look like "not an app" and go silent again. |
| `raise X from Y` mutates X | Unwrapping and re-raising built a chain where `exc.__cause__.__cause__ is exc`. Anything walking it loops. |
| Wrapping breaks documented contracts | `load()` documents `ModuleNotFoundError`; wrapping made its own handler unreachable. |

The subclass rule is deliberately written as a contract — "subclassing `DetectionError` is how a new failure kind reaches existing handlers" — rather than naming a specific class, so it holds regardless of what the error hierarchy looks like on any given day. It also means this PR doesn't reference anything that isn't already on `main`; I checked before committing, because an earlier draft named a class that only exists in unmerged #101.

## `docs/reviewing.md`

The procedural half, in step 5: **check that your check could have failed.**

A verification that cannot detect the problem reports success exactly as confidently as one that can. Two false all-clears in this session:

- grepping command output for `Traceback` — Typer renders them through rich, as a box that never contains that word. I reported four commands clean while all four were dumping tracebacks.
- reading `$?` after a shell pipeline, which gives the exit status of `tail`.

Both said "fine" while the code was broken. The rule: break it on purpose and confirm the check goes red first.

## Scope

Guidance only — no source or behaviour changes. `make check`: 419 passed; the doc-path guard passes.

Merges cleanly in any order relative to #101.
