### PR TITLE
docs: align conversion limits and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@ intpot add skills --path ./myproject/
 - **Six conversion directions:** move existing apps between all three frameworks.
 - **Standalone output:** eject or convert to normal framework code with no intpot runtime
   dependency.
-- **Behavior-aware transforms:** preserve function bodies and imports, and translate
-  framework conventions such as `typer.echo()` into return values.
+- **Behavior-aware transforms:** preserve recoverable function bodies and the direct
+  imports they use, and translate framework conventions such as `typer.echo()` into
+  return values.
 - **Interface fidelity:** carry types, defaults, and async functions through supported
   conversions, and apply FastAPI parameter sources when generating an API.
 - **Programmatic access:** use `intpot.load()` and normalized `ToolInfo` objects from
@@ -272,16 +273,25 @@ frameworks share:
 - scalar returns translated into a shape the target framework can serve correctly.
 
 Frameworks do not have one-to-one equivalents for every feature. Review generated code
-when a source uses nested Typer command groups, `Annotated[..., Body(...)]`, FastAPI
-`Depends()`, Pydantic model parameters, streaming, background tasks, or framework-specific
-error handling. Transitive imports, external services, and configuration are not
-provisioned for you. If intpot cannot recover a body, it emits a `# TODO: implement` stub
-instead of inventing behavior.
+when a source uses nested Typer command groups, repeatable CLI options,
+`Annotated[..., Body(...)]`, FastAPI `Depends()`, Pydantic model parameters, routes with
+multiple HTTP methods, streaming, background tasks, or framework-specific error handling.
+
+intpot carries direct import statements referenced by a tool body. It does not yet copy
+same-module helpers, constants, classes, models, or closure values that the body
+references, and it does not follow dependencies across imported modules. Factory-created
+apps are not detected by the current AST pre-check. Loading a source file directly also
+does not add its directory to `sys.path`, so a sibling import such as
+`from helpers import normalize` may require installing the package or setting
+`PYTHONPATH`. External services and configuration are not provisioned for you. If intpot
+cannot recover a body, it emits a `# TODO: implement` stub instead of inventing behavior.
 
 > [!IMPORTANT]
-> Detection imports the source module, so only inspect or convert code you trust. intpot
-> is alpha software: compile the generated file, import it with its dependencies, and
-> exercise a real CLI command, API request, or MCP tool before shipping it.
+> Detection imports the source module, so only inspect or convert code you trust. A source
+> that cannot be parsed or imported is reported cleanly; during a directory conversion,
+> intpot reports the bad file and continues with the rest. intpot is alpha software:
+> compile the generated file, import it with its dependencies, and exercise a real CLI
+> command, API request, or MCP tool before shipping it.
 
 ## Architecture
 
@@ -322,8 +332,10 @@ The repository includes checked-in source and generated output for every directi
 | FastMCP | [`mcp_to_cli.py`](examples/conversions/mcp_to_cli.py) | [`mcp_to_api.py`](examples/conversions/mcp_to_api.py) | — |
 
 [`examples/`](examples/) also contains advanced inputs and outputs with direct imports,
-async tools, request bodies, `Depends()`, path parameters, and multiple HTTP methods.
-Run `bash scripts/demo.sh` to regenerate all twelve conversions locally.
+async tools, request bodies, `Depends()`, and path parameters. The FastAPI input includes
+routes with multiple HTTP methods; that case is intentionally visible even though current
+conversion keeps only one method. Run `bash scripts/demo.sh` to regenerate all twelve
+conversions locally.
 
 ## CLI Reference
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,22 @@ Define tools once with `@app.tool()` and serve them as a CLI, API, or MCP server
 eject them to standalone framework code. The converter handles all six directions between
 existing Typer, FastMCP, and FastAPI apps.
 
-### Remaining polish
+### Conversion correctness
+
+- [ ] Carry the complete dependency closure within one source module: referenced helper
+      functions, constants, classes, models, defaults, decorators, annotations, and base
+      classes. This stops generated tools raising `NameError` without following imports
+      into other modules.
+- [ ] Preserve repeatable Typer/Click options and collection cardinality when converting
+      to API or MCP schemas.
+- [ ] Support package and sibling imports when detecting a source file directly. Detection
+      currently imports by file path without adding the source directory to `sys.path`.
+- [ ] Detect apps created by factories such as `app = create_app()` without broadening
+      directory discovery into importing every Python file.
+- [ ] Define and preserve multi-method FastAPI route semantics. `ToolInfo` currently stores
+      one HTTP method, so a route registered for several methods is lossy.
+
+### Framework polish
 
 - [ ] Handle `Annotated[str, Body(...)]` style FastAPI parameters ([#1](https://github.com/tugrulguner/intpot/issues/1))
 - [ ] Emit nested command hierarchies. Reading them works; see "Already shipped". What's
@@ -34,7 +49,13 @@ than planned:
   Generating a nested hierarchy back out is still open (#2).
 - **Round-trip fidelity tests** — `tests/test_roundtrip.py` covers all three pairings.
 - **Direct import resolution** — imports referenced by a function body are carried into
-  the generated file. Transitive dependencies are not yet followed.
+  the generated file, including dotted and mixed import statements. Same-module
+  declarations and dependencies across imported modules are not yet followed.
+- **Collision-safe directory output** — directory conversion mirrors the source tree, so
+  files with the same basename in separate packages cannot overwrite each other.
+- **Actionable source failures** — import errors, syntax errors, and import-time
+  `sys.exit()` calls are reported without a traceback. Directory scans report a bad file,
+  continue, and convert the remaining apps.
 
 ## v2 — Full AST Transform Pipeline
 
@@ -52,8 +73,8 @@ transformations that need real understanding of what a function body does.
 - **Pydantic model parameters** ([#17](https://github.com/tugrulguner/intpot/issues/17)) —
   expand a model argument into individual CLI/MCP parameters instead of treating it as one
   opaque value
-- **Transitive import resolution** — follow what the body's own dependencies need, not
-  just the names it mentions directly
+- **Cross-module dependency resolution** — after same-module dependency closure is
+  reliable, follow dependencies through imported project modules and packages
 - **Full error-handling conversion** — Typer exits are mapped today; HTTP exceptions and
   MCP error patterns are not
 
@@ -67,7 +88,8 @@ transformations that need real understanding of what a function body does.
 
 ---
 
-Every item above is tracked as an issue. If something here interests you,
+Linked items above are tracked as issues; unlinked items are directional roadmap work and
+should get a focused issue before implementation. If something here interests you,
 [CONTRIBUTING.md](CONTRIBUTING.md) has the setup and
 [good first issues](https://github.com/tugrulguner/intpot/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 are a gentler place to start.

--- a/changelog.d/107.changed.md
+++ b/changelog.d/107.changed.md
@@ -1,0 +1,1 @@
+The README, roadmap, and installed coding-agent guidance now state the converter's current fidelity limits and planned correctness work.

--- a/src/intpot/templates/skills/intpot-cli.md
+++ b/src/intpot/templates/skills/intpot-cli.md
@@ -124,12 +124,18 @@ conversion or eject:
    `TestClient`, or call a generated MCP tool. Checking text or `--help` alone is not a
    behavioral test.
 
-Current unsupported or lossy cases include nested Typer sub-apps, some FastAPI
-`Annotated[..., Body(...)]` parameters, and `Depends()` (recorded in a comment but
-stripped from non-API targets). A missing recoverable body becomes a `# TODO: implement`
-stub. intpot carries source imports it can identify, but it does not discover or install
-transitive dependencies, reproduce configuration, or provision external services; verify
-those explicitly rather than assuming generated code is standalone.
+Current unsupported or lossy cases include nested Typer sub-apps, repeatable CLI options,
+some FastAPI `Annotated[..., Body(...)]` parameters, `Depends()` (recorded in a comment
+but stripped from non-API targets), factory-created apps, and routes with multiple HTTP
+methods. A missing recoverable body becomes a `# TODO: implement` stub.
+
+intpot carries direct import statements referenced by a tool body. It does not yet copy
+same-module helpers, constants, classes, models, or closure values. It does not discover
+or install transitive dependencies across imported modules. Direct file loading does not
+add the source directory to `sys.path`, so sibling imports may require installing the
+package or setting `PYTHONPATH`. intpot does not reproduce configuration or provision
+external services; verify those explicitly rather than assuming generated code is
+standalone.
 
 ## Installation
 

--- a/src/intpot/templates/skills/intpot-python.md
+++ b/src/intpot/templates/skills/intpot-python.md
@@ -96,13 +96,20 @@ other two.
 
 Generated strings still need runtime verification. Successful generation does not prove
 the result works: compile it, import it with its runtime dependencies installed, then
-invoke a real CLI command, API request, or MCP tool. intpot does not discover or install
-transitive dependencies, reproduce configuration, or provision external services.
+invoke a real CLI command, API request, or MCP tool.
 
-Current unsupported or lossy conversions include nested Typer sub-apps, some FastAPI
-`Annotated[..., Body(...)]` parameters, and `Depends()` when targeting CLI or MCP. A body
-that cannot be recovered becomes a `# TODO: implement` stub; inspect and implement it
-before treating the output as complete.
+Current unsupported or lossy conversions include nested Typer sub-apps, repeatable CLI
+options, some FastAPI `Annotated[..., Body(...)]` parameters, `Depends()` when targeting
+CLI or MCP, factory-created apps, and routes with multiple HTTP methods. A body that cannot
+be recovered becomes a `# TODO: implement` stub; inspect and implement it before treating
+the output as complete.
+
+intpot carries direct import statements referenced by a tool body. It does not yet copy
+same-module helpers, constants, classes, models, or closure values. It does not discover
+or install transitive dependencies across imported modules. Direct file loading does not
+add the source directory to `sys.path`, so sibling imports may require installing the
+package or setting `PYTHONPATH`. intpot does not reproduce configuration or provision
+external services.
 
 ## Normalized tool data
 


### PR DESCRIPTION
## Summary

- state the converter's current fidelity boundaries precisely in the README
- separate same-module dependency closure from future cross-module resolution in the roadmap
- record the current correctness backlog and the reliability work shipped in v0.7
- keep the CLI and Python coding-agent skills aligned with the public documentation

## Why

The README described direct import preservation too broadly, presented multi-method FastAPI examples without naming the lossy behavior, and omitted several known conversion limits. The roadmap was at v0.7 but did not contain the current correctness backlog and claimed every item had an issue even when some directional work did not.

## Verification

- `uv run pytest tests/test_docs.py tests/test_skills_content.py -q` — 72 passed
- `make check` on Python 3.13 — 448 passed
- `uv build --out-dir /tmp/intpot-docs-dist`
- `uvx --from twine twine check /tmp/intpot-docs-dist/*`
- `git diff --check`

Python 3.14 was not used as verification because intpot currently supports Python 3.11–3.13; the canonical suite passes on Python 3.13.
