### PR TITLE
fix: support Python 3.14 AST changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/changelog.d/108.fixed.md
+++ b/changelog.d/108.fixed.md
@@ -1,0 +1,1 @@
+Function body extraction no longer crashes on Python 3.14, which removed the deprecated `ast.Str` alias.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Code Generators",
     "Typing :: Typed",
 ]

--- a/src/intpot/core/inspectors/_utils.py
+++ b/src/intpot/core/inspectors/_utils.py
@@ -171,9 +171,7 @@ def extract_function_body(fn: Any) -> str | None:
 
     # Find the first real statement, skipping a leading docstring
     first_stmt = func_node.body[0]
-    if isinstance(first_stmt, ast.Expr) and isinstance(
-        first_stmt.value, (ast.Constant, ast.Str)
-    ):
+    if isinstance(first_stmt, ast.Expr) and isinstance(first_stmt.value, ast.Constant):
         if len(func_node.body) <= 1:
             return None  # Only a docstring, no real body
         first_stmt = func_node.body[1]


### PR DESCRIPTION
## Summary

- replace the removed `ast.Str` compatibility alias with `ast.Constant`
- add Python 3.14 to package classifiers and the CI test matrix
- prevent function-body extraction from crashing when a tool has a docstring on Python 3.14

## Reproduction

Before the fix, Python 3.14 failed the existing behavioral regression:

```text
AttributeError: module 'ast' has no attribute 'Str'
```

That failure propagated through inspection, conversion, ejection, and runtime tool registration.

## Verification

- RED: `test_docstring_is_skipped` failed on Python 3.14 with the removed `ast.Str`
- GREEN: focused regression passed on Python 3.14
- `make check` on Python 3.14 — 448 passed
- `make check` on Python 3.11 — 448 passed
- `git diff --check`
