### PR TITLE
release: v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ release assembles them here — run `make changelog-draft` to preview them.
 
 <!-- towncrier release notes start -->
 
+## [0.7.1] - 2026-08-24
+
+### Changed
+
+- The README, roadmap, and installed coding-agent guidance now state the converter's current fidelity limits and planned correctness work. ([#107](https://github.com/tugrulguner/intpot/pull/107))
+
+### Fixed
+
+- Function body extraction no longer crashes on Python 3.14, which removed the deprecated `ast.Str` alias. ([#108](https://github.com/tugrulguner/intpot/pull/108))
+
+
 ## [0.7.0] - 2026-08-21
 
 ### Changed

--- a/changelog.d/107.changed.md
+++ b/changelog.d/107.changed.md
@@ -1,1 +1,0 @@
-The README, roadmap, and installed coding-agent guidance now state the converter's current fidelity limits and planned correctness work.

--- a/changelog.d/108.fixed.md
+++ b/changelog.d/108.fixed.md
@@ -1,1 +1,0 @@
-Function body extraction no longer crashes on Python 3.14, which removed the deprecated `ast.Str` alias.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "intpot"
-version = "0.7.0"
+version = "0.7.1"
 description = "Define Python tools once and serve them as a Typer CLI, FastAPI app, or FastMCP server — or convert existing apps between all three"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -651,7 +651,7 @@ wheels = [
 
 [[package]]
 name = "intpot"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Release scope

v0.7.1 publishes two changes that are already merged into `main`:

- #107 updated `README.md`, `ROADMAP.md`, and both installed coding-agent guides to state current conversion boundaries accurately.
- #108 fixed function-body extraction on Python 3.14 and added Python 3.14 to package classifiers and CI.

Those source and documentation changes do not appear in this PR's diff because this release branch was created after both PRs merged. They are present in the release history and built artifacts.

## What this release-preparation PR changes

- Bumps the canonical package version from 0.7.0 to 0.7.1 with `uv version --bump patch`.
- Updates `uv.lock` through the same command.
- Assembles fragments #107 and #108 into `CHANGELOG.md` with Towncrier.
- Removes the two consumed fragments.

## Verification

- Release diff from `v0.7.0` includes the merged README, roadmap, and both packaged skill-template updates from #107.
- `make check` on Python 3.14: 448 passed
- Documentation and packaged-skill tests: 72 passed
- Release tag/version/changelog gate simulated for `v0.7.1`
- Wheel and sdist built successfully
- Twine checks passed for both artifacts
- Built wheel metadata, Python 3.14 classifier, package structure, and installed skill content verified directly
- Fresh-wheel E2E passed on Python 3.11 and 3.14:
  - installed version and README-based metadata
  - `intpot.App` function-body extraction
  - generated FastAPI request
  - CLI serving
  - API ejection and compilation
  - `intpot add skills` packaged guidance

## After merge

Tag the exact merge commit as `v0.7.1` and push the tag. The release workflow will rerun CI, verify version/changelog consistency, build clean artifacts, publish through PyPI trusted publishing, and create the GitHub Release.
