### PR TITLE
fix: support declared FastMCP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
   workflow_call:
+  workflow_dispatch:
+  schedule:
+    # Floating dependencies run out of band so a new upstream release cannot
+    # unexpectedly block an otherwise unrelated pull request.
+    - cron: "17 7 * * 1"
 
 permissions:
   contents: read
@@ -61,6 +66,85 @@ jobs:
           --cov=src/intpot
           --cov-report=term-missing
           --cov-fail-under=80
+
+  compatibility-oldest:
+    name: oldest (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Typer 0.9.0
+            editable: "."
+            framework: "typer==0.9.0"
+            package: typer
+            version: "0.9.0"
+            tests: tests/test_inspectors/test_cli_inspector.py
+          - name: FastAPI 0.100.0
+            editable: ".[api]"
+            framework: "fastapi==0.100.0"
+            package: fastapi
+            version: "0.100.0"
+            tests: tests/test_inspectors/test_api_inspector.py
+          - name: FastMCP 2.0.0
+            editable: ".[mcp]"
+            framework: "fastmcp==2.0.0"
+            package: fastmcp
+            version: "2.0.0"
+            tests: tests/test_inspectors/test_mcp_inspector.py
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.11"
+      - name: Exercise declared lower bound
+        env:
+          EDITABLE: ${{ matrix.editable }}
+          FRAMEWORK: ${{ matrix.framework }}
+          PACKAGE: ${{ matrix.package }}
+          VERSION: ${{ matrix.version }}
+          TESTS: ${{ matrix.tests }}
+        run: |
+          run=(uv run --no-project --python 3.11 --with-editable "$EDITABLE" --with "$FRAMEWORK" --with pytest)
+          "${run[@]}" python -c 'from importlib.metadata import version; import os; actual = version(os.environ["PACKAGE"]); expected = os.environ["VERSION"]; assert actual == expected, (actual, expected)'
+          "${run[@]}" pytest "$TESTS" -q
+
+  compatibility-fastmcp-2-latest:
+    name: latest FastMCP 2.x
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.11"
+      - name: Exercise latest FastMCP 2.x
+        run: |
+          run=(uv run --no-project --python 3.11 --with-editable '.[mcp]' --with 'fastmcp>=2,<3' --with pytest)
+          "${run[@]}" python -c 'from importlib.metadata import version; actual = version("fastmcp"); assert actual.startswith("2."), actual'
+          "${run[@]}" pytest tests/test_inspectors/test_mcp_inspector.py -q
+
+  compatibility-latest:
+    name: latest dependencies
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.11"
+      - name: Exercise newest resolvable dependencies
+        run: >-
+          uv run --no-project --python 3.11 --with-editable '.[dev]'
+          pytest tests/ -q
 
   build:
     name: build

--- a/changelog.d/113.fixed.md
+++ b/changelog.d/113.fixed.md
@@ -1,0 +1,1 @@
+FastMCP 2.x applications are inspected correctly, and MCP parameter descriptions are preserved across conversions.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -162,7 +162,7 @@ Descriptions carry over between frameworks where possible:
 
 - `typer.Argument(..., help="...")` -> `Body(..., description="...")`
 - `Body(..., description="...")` -> `typer.Option(..., help="...")`
-- MCP tools don't have per-parameter descriptions in the decorator, so descriptions are empty when converting *from* MCP
+- FastMCP parameter descriptions exposed in a tool's JSON Schema are preserved when converting from MCP
 
 ## HTTP method preservation
 
@@ -217,7 +217,7 @@ Converting from A to B and back to A won't give you identical code. Things that 
 - **Route paths** may change (e.g. `/users/{user_id}` becomes `/users_user_id` or similar)
 - **`Depends()` calls** are stripped and replaced with comments
 - **Formatting** will differ (intpot generates from templates, not from your original formatting)
-- **Parameter descriptions** from MCP are empty, so a round trip MCP -> API -> MCP loses descriptions that existed in the API version
+- **Parameter descriptions** absent from a source framework's metadata cannot be recovered
 
 The function bodies are generally preserved well though, especially for simple functions.
 

--- a/src/intpot/commands/_convert.py
+++ b/src/intpot/commands/_convert.py
@@ -8,8 +8,17 @@ from pathlib import Path
 import typer
 
 from intpot.converter import inspect_app
+from intpot.core.inspectors.base import InspectionError
 from intpot.core.models import SourceType
 from intpot.core.transforms import transform_tools
+
+
+def _inspect_or_exit(source_type: SourceType, app_instance: object):
+    try:
+        return inspect_app(source_type, app_instance)
+    except InspectionError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from None
 
 
 def _mirrored_destination(
@@ -116,7 +125,7 @@ def convert(
         for (file_path, source_type, app_instance), destination in zip(
             sources, destinations, strict=True
         ):
-            tools = inspect_app(source_type, app_instance)
+            tools = _inspect_or_exit(source_type, app_instance)
             tools = transform_tools(tools, source_type, target)
             code = generator.generate(tools)
 
@@ -153,7 +162,7 @@ def convert(
         typer.echo(f"Source is already a {label}.", err=True)
         raise typer.Exit(1)
 
-    tools = inspect_app(source_type, app_instance)
+    tools = _inspect_or_exit(source_type, app_instance)
     tools = transform_tools(tools, source_type, target)
     code = generator.generate(tools)
 

--- a/src/intpot/commands/inspect.py
+++ b/src/intpot/commands/inspect.py
@@ -10,7 +10,16 @@ from pathlib import Path
 import typer
 
 from intpot.converter import inspect_app
+from intpot.core.inspectors.base import InspectionError
 from intpot.core.models import SourceType
+
+
+def _inspect_or_exit(source_type: SourceType, app_instance: object):
+    try:
+        return inspect_app(source_type, app_instance)
+    except InspectionError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from None
 
 
 def _serialize_tool(tool):
@@ -55,7 +64,7 @@ def inspect_command(
 
         all_results = []
         for file_path, source_type, app_instance in sources:
-            tools = inspect_app(source_type, app_instance)
+            tools = _inspect_or_exit(source_type, app_instance)
             all_results.append((file_path, source_type, tools))
 
         if as_json:
@@ -89,7 +98,7 @@ def inspect_command(
     if verbose:
         print(f"FOUND: {source} ({source_type.value})", file=sys.stderr)
 
-    tools = inspect_app(source_type, app_instance)
+    tools = _inspect_or_exit(source_type, app_instance)
 
     if as_json:
         out = [

--- a/src/intpot/core/inspectors/base.py
+++ b/src/intpot/core/inspectors/base.py
@@ -8,6 +8,10 @@ from typing import Any
 from intpot.core.models import ToolInfo
 
 
+class InspectionError(RuntimeError):
+    """A framework app was detected but could not be inspected safely."""
+
+
 class BaseInspector(ABC):
     @abstractmethod
     def inspect(self, app: Any) -> list[ToolInfo]:

--- a/src/intpot/core/inspectors/mcp.py
+++ b/src/intpot/core/inspectors/mcp.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import inspect
-from typing import Any
+from collections.abc import Callable, Coroutine, Mapping
+from typing import Annotated, Any, cast, get_args, get_origin
 
 from intpot.core.inspectors._utils import (
     extract_function_body,
@@ -12,7 +14,7 @@ from intpot.core.inspectors._utils import (
     python_return_type_name,
     python_type_name,
 )
-from intpot.core.inspectors.base import BaseInspector
+from intpot.core.inspectors.base import BaseInspector, InspectionError
 from intpot.core.models import _SENTINEL, ParameterInfo, ToolInfo
 
 
@@ -25,26 +27,71 @@ def _is_mcp_context(annotation: Any) -> bool:
     return False
 
 
+def _base_annotation(annotation: Any) -> Any:
+    """Return the executable Python type beneath Annotated metadata."""
+    while get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+    return annotation
+
+
+def _unsupported_registry_error() -> InspectionError:
+    return InspectionError(
+        "Unsupported FastMCP registry shape: expected "
+        "local_provider._list_tools() (FastMCP 3) or "
+        "_tool_manager.list_tools()/get_tools() (FastMCP 2). Please install a "
+        "supported FastMCP 2.x or 3.x release."
+    )
+
+
+def _run_async(factory: Callable[[], Coroutine[Any, Any, Any]]) -> Any:
+    """Run a framework coroutine from synchronous or asynchronous callers."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(factory())
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(lambda: asyncio.run(factory())).result()
+
+
+def _call_registry(factory: Callable[[], Any]) -> Any:
+    """Call a registry method that may be synchronous or asynchronous."""
+
+    async def invoke() -> Any:
+        result = factory()
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    return _run_async(invoke)
+
+
 class MCPInspector(BaseInspector):
     def inspect(self, app: Any) -> list[ToolInfo]:
         tools: list[ToolInfo] = []
 
-        # FastMCP >=2.0 stores tools via local_provider
-        # Use the async _list_tools to get registered FunctionTool objects
+        # FastMCP 3 stores tools via local_provider; FastMCP 2 uses
+        # _tool_manager. Match the registries structurally rather than importing
+        # generation-specific implementation types.
         provider = getattr(app, "local_provider", None)
         if provider is None:
-            return tools
+            manager = getattr(app, "_tool_manager", None)
+            list_tools = cast(Any, getattr(manager, "list_tools", None))
+            if not callable(list_tools):
+                list_tools = cast(Any, getattr(manager, "get_tools", None))
+            if not callable(list_tools):
+                raise _unsupported_registry_error()
+            function_tools: Any = _call_registry(list_tools)
+        else:
+            list_tools = cast(
+                Callable[[], Any] | None, getattr(provider, "_list_tools", None)
+            )
+            if not callable(list_tools):
+                raise _unsupported_registry_error()
+            function_tools = _call_registry(list_tools)
 
-        try:
-            function_tools = asyncio.run(provider._list_tools())
-        except RuntimeError:
-            # Already in an async context — create a new event loop in a thread
-            import concurrent.futures
-
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                function_tools = pool.submit(
-                    asyncio.run, provider._list_tools()
-                ).result()
+        if isinstance(function_tools, Mapping):
+            function_tools = function_tools.values()
 
         for ft in function_tools:
             fn = getattr(ft, "fn", None)
@@ -57,6 +104,8 @@ class MCPInspector(BaseInspector):
                 description = fn.__doc__.strip()
 
             sig = inspect.signature(fn)
+            parameter_schema = getattr(ft, "parameters", {})
+            schema_properties = parameter_schema.get("properties", {})
             type_hints: dict[str, Any] = {}
             try:
                 type_hints = inspect.get_annotations(fn, eval_str=True)
@@ -65,7 +114,9 @@ class MCPInspector(BaseInspector):
 
             params: list[ParameterInfo] = []
             for param_name, param in sig.parameters.items():
-                annotation = type_hints.get(param_name, param.annotation)
+                annotation = _base_annotation(
+                    type_hints.get(param_name, param.annotation)
+                )
                 if _is_mcp_context(annotation):
                     continue
                 type_str = python_type_name(annotation)
@@ -79,11 +130,16 @@ class MCPInspector(BaseInspector):
                         name=param_name,
                         type_annotation=type_str,
                         default=default,
-                        description="",
+                        description=schema_properties.get(param_name, {}).get(
+                            "description", ""
+                        )
+                        or "",
                     )
                 )
 
-            return_annotation = type_hints.get("return", sig.return_annotation)
+            return_annotation = _base_annotation(
+                type_hints.get("return", sig.return_annotation)
+            )
             return_type = python_return_type_name(return_annotation)
 
             tools.append(

--- a/tests/test_commands/test_inspect.py
+++ b/tests/test_commands/test_inspect.py
@@ -102,3 +102,20 @@ def test_inspect_nonexistent_file():
     result = runner.invoke(app, ["inspect", "/tmp/no_such_file_xyz.py"])
     assert result.exit_code != 0
     assert "Traceback" not in result.output
+
+
+def test_inspect_unknown_mcp_registry_reports_compatibility_error(tmp_source):
+    source = tmp_source("""
+        class FastMCP:
+            pass
+
+        FastMCP.__module__ = "fastmcp.future"
+        mcp = FastMCP()
+    """)
+
+    result = runner.invoke(app, ["inspect", str(source)])
+
+    assert result.exit_code == 1
+    assert "Unsupported FastMCP registry shape" in result.stderr
+    assert "supported FastMCP 2.x or 3.x" in result.stderr
+    assert "Traceback" not in result.output

--- a/tests/test_commands/test_to_cli.py
+++ b/tests/test_commands/test_to_cli.py
@@ -82,3 +82,19 @@ def test_cli_to_cli_fails(tmp_source):
     """)
     result = runner.invoke(app, ["to", "cli", str(source)])
     assert result.exit_code == 1
+
+
+def test_mcp_compatibility_error_does_not_leak_from_conversion(tmp_source):
+    source = tmp_source("""
+        class FastMCP:
+            pass
+
+        FastMCP.__module__ = "fastmcp.future"
+        mcp = FastMCP()
+    """)
+
+    result = runner.invoke(app, ["to", "cli", str(source)])
+
+    assert result.exit_code == 1
+    assert "Unsupported FastMCP registry shape" in result.stderr
+    assert "Traceback" not in result.output

--- a/tests/test_inspectors/test_mcp_inspector.py
+++ b/tests/test_inspectors/test_mcp_inspector.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
+
+import pytest
 from fastmcp import FastMCP
 
+from intpot.core.inspectors.base import InspectionError
 from intpot.core.inspectors.mcp import MCPInspector
 
 
@@ -44,3 +49,125 @@ def test_inspect_empty_mcp():
     inspector = MCPInspector()
     tools = inspector.inspect(mcp)
     assert tools == []
+
+
+def test_inspect_fastmcp_2_tool_manager_registry():
+    def greet(name: str) -> str:
+        return f"Hello, {name}!"
+
+    tool = SimpleNamespace(
+        fn=greet,
+        name="greet",
+        description="Greet someone.",
+        parameters={"properties": {"name": {"type": "string"}}},
+    )
+    app = SimpleNamespace(
+        _tool_manager=SimpleNamespace(list_tools=lambda: [tool]),
+    )
+
+    tools = MCPInspector().inspect(app)
+
+    assert [tool.name for tool in tools] == ["greet"]
+
+
+def test_inspect_late_fastmcp_2_async_tool_manager_registry():
+    def greet(name: str) -> str:
+        return f"Hello, {name}!"
+
+    tool = SimpleNamespace(
+        fn=greet,
+        name="greet",
+        description="Greet someone.",
+        parameters={"properties": {"name": {"type": "string"}}},
+    )
+
+    class ToolManager:
+        async def get_tools(self):
+            return {"greet": tool}
+
+    tools = MCPInspector().inspect(SimpleNamespace(_tool_manager=ToolManager()))
+
+    assert [inspected.name for inspected in tools] == ["greet"]
+
+
+def test_inspect_fastmcp_3_local_provider_registry():
+    def greet(name: str) -> str:
+        return f"Hello, {name}!"
+
+    tool = SimpleNamespace(
+        fn=greet,
+        name="greet",
+        description="Greet someone.",
+        parameters={"properties": {"name": {"type": "string"}}},
+    )
+
+    class LocalProvider:
+        async def _list_tools(self):
+            return [tool]
+
+    app = SimpleNamespace(local_provider=LocalProvider())
+
+    tools = MCPInspector().inspect(app)
+
+    assert [tool.name for tool in tools] == ["greet"]
+
+
+def test_inspect_fastmcp_3_from_a_running_event_loop():
+    def greet(name: str) -> str:
+        return f"Hello, {name}!"
+
+    tool = SimpleNamespace(
+        fn=greet,
+        name="greet",
+        description="Greet someone.",
+        parameters={"properties": {"name": {"type": "string"}}},
+    )
+
+    class LocalProvider:
+        async def _list_tools(self):
+            return [tool]
+
+    async def inspect_inside_loop():
+        return MCPInspector().inspect(SimpleNamespace(local_provider=LocalProvider()))
+
+    tools = asyncio.run(inspect_inside_loop())
+
+    assert [inspected.name for inspected in tools] == ["greet"]
+
+
+def test_inspect_uses_mcp_parameter_schema_descriptions():
+    def greet(name: str) -> str:
+        return f"Hello, {name}!"
+
+    tool = SimpleNamespace(
+        fn=greet,
+        name="greet",
+        description="Greet someone.",
+        parameters={
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Person to greet.",
+                }
+            }
+        },
+    )
+    app = SimpleNamespace(
+        _tool_manager=SimpleNamespace(list_tools=lambda: [tool]),
+    )
+
+    [inspected] = MCPInspector().inspect(app)
+
+    assert inspected.parameters[0].description == "Person to greet."
+
+
+def test_inspect_rejects_unknown_fastmcp_registry_shape():
+    with pytest.raises(InspectionError, match="Unsupported FastMCP registry shape"):
+        MCPInspector().inspect(SimpleNamespace())
+
+
+def test_inspect_rejects_unknown_fastmcp_local_provider_shape():
+    app = SimpleNamespace(local_provider=SimpleNamespace())
+
+    with pytest.raises(InspectionError, match="Unsupported FastMCP registry shape"):
+        MCPInspector().inspect(app)

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from types import ModuleType
+
+from fastapi.testclient import TestClient
 
 from intpot.converter import load
 
@@ -100,6 +103,41 @@ class TestMCPRoundtrips:
         assert compile(api_code, "<string>", "exec")
         assert "def greet" in api_code
         assert "def add" in api_code
+
+    def test_mcp_to_api_preserves_schema_description_and_runs(
+        self, tmp_path: Path
+    ) -> None:
+        source = textwrap.dedent("""\
+            from typing import Annotated
+
+            from fastmcp import FastMCP
+            from pydantic import Field
+
+            mcp = FastMCP("test-server")
+
+            @mcp.tool()
+            def greet(
+                name: Annotated[str, Field(description="Person to greet.")],
+            ) -> str:
+                return f"Hello, {name}!"
+        """)
+        path = tmp_path / "described_mcp.py"
+        path.write_text(source)
+
+        api_code = load(path).to_api()
+
+        assert "name: str" in api_code
+        generated = ModuleType("generated_described_api")
+        exec(
+            compile(api_code, "generated_described_api.py", "exec"), generated.__dict__
+        )
+        client = TestClient(generated.app)
+        operation = client.get("/openapi.json").json()["paths"]["/greet"]["post"]
+        body_schema = operation["requestBody"]["content"]["application/json"]["schema"]
+        assert body_schema["description"] == "Person to greet."
+        response = client.post("/greet", json="Ada")
+        assert response.status_code == 200
+        assert response.json() == {"result": "Hello, Ada!"}
 
 
 class TestCLIRoundtrips:


### PR DESCRIPTION
## Problem

intpot declares `fastmcp>=2.0.0`, but inspection only understood FastMCP 3's `local_provider`. Real FastMCP 2 applications therefore appeared to contain zero tools. MCP parameter descriptions exposed by FastMCP's JSON Schema were also discarded, and the locked CI graph did not exercise the declared framework lower bounds.

## Approach

- Adapt structurally to FastMCP 2's `_tool_manager` and FastMCP 3's `local_provider` registries.
- Raise an actionable inspection error for unknown registry layouts and surface it cleanly through CLI commands.
- Read parameter descriptions from each tool's JSON Schema while unwrapping `Annotated` metadata to executable Python types.
- Add exact lower-bound lanes for Typer 0.9.0, FastAPI 0.100.0, and FastMCP 2.0.0, plus a latest FastMCP 2.x lane.
- Add a scheduled/manual newest-resolvable dependency lane.

## Verification

- `make check` — 458 tests passed; Ruff and Pyright passed.
- Actionlint 1.7.12 passed on `.github/workflows/ci.yml`.
- Typer 0.9.0 inspector suite — 6 passed.
- FastAPI 0.100.0 inspector suite — 10 passed.
- FastMCP 2.0.0 inspector suite — 9 passed.
- Latest FastMCP 2.x (2.14.7 at verification) inspector suite — 9 passed.
- End-to-end MCP-to-API regression compiles and executes generated source, verifies the OpenAPI parameter description, and invokes the endpoint through `TestClient`.

## Risk and scope

The adapters use structural attributes rather than version checks or private class identity. Unknown future layouts fail explicitly instead of silently losing tools. This does not redesign `ToolInfo` or broaden unrelated conversion semantics.

Closes #111
