### PR TITLE
release: v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ release assembles them here — run `make changelog-draft` to preview them.
 
 - Checked-in generated examples are now executed through real CLI, MCP, and FastAPI behavior during verification.
 - FastAPI conversions now reject unsupported dependency injection instead of generating code that can fail at runtime.
-  Typer 0.9 remains usable with current Click releases across intpot's public CLI and Typer app conversion.
+- Typer 0.9 remains usable with current Click releases across intpot's public CLI and Typer app conversion.
 - FastMCP 2.x applications are inspected correctly, and MCP parameter descriptions are preserved across conversions.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ release assembles them here — run `make changelog-draft` to preview them.
 
 <!-- towncrier release notes start -->
 
+## [0.7.2] - 2026-08-28
+
+### Changed
+
+- Add structured contributor onboarding and issue-backed or generated orphan changelog fragments.
+
+### Fixed
+
+- Checked-in generated examples are now executed through real CLI, MCP, and FastAPI behavior during verification.
+- FastAPI conversions now reject unsupported dependency injection instead of generating code that can fail at runtime.
+  Typer 0.9 remains usable with current Click releases across intpot's public CLI and Typer app conversion.
+- FastMCP 2.x applications are inspected correctly, and MCP parameter descriptions are preserved across conversions.
+
+
 ## [0.7.1] - 2026-08-24
 
 ### Changed

--- a/changelog.d/+3e22ff77.fixed.md
+++ b/changelog.d/+3e22ff77.fixed.md
@@ -1,1 +1,0 @@
-Checked-in generated examples are now executed through real CLI, MCP, and FastAPI behavior during verification.

--- a/changelog.d/+8ed26890.fixed.md
+++ b/changelog.d/+8ed26890.fixed.md
@@ -1,1 +1,0 @@
-FastMCP 2.x applications are inspected correctly, and MCP parameter descriptions are preserved across conversions.

--- a/changelog.d/+98dd309d.changed.md
+++ b/changelog.d/+98dd309d.changed.md
@@ -1,1 +1,0 @@
-Add structured contributor onboarding and issue-backed or generated orphan changelog fragments.

--- a/changelog.d/+d2d6e1e2.fixed.md
+++ b/changelog.d/+d2d6e1e2.fixed.md
@@ -1,2 +1,0 @@
-FastAPI conversions now reject unsupported dependency injection instead of generating code that can fail at runtime.
-Typer 0.9 remains usable with current Click releases across intpot's public CLI and Typer app conversion.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "intpot"
-version = "0.7.1"
+version = "0.7.2"
 description = "Define Python tools once and serve them as a Typer CLI, FastAPI app, or FastMCP server — or convert existing apps between all three"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -651,7 +651,7 @@ wheels = [
 
 [[package]]
 name = "intpot"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Prepare intpot 0.7.2 for publication.

## Release scope already on `main`

- FastMCP 2.x and 3.x registry compatibility with preserved MCP parameter descriptions.
- Explicit rejection of FastAPI dependency-injection conversions that cannot be represented safely.
- Typer 0.9 compatibility with current Click releases, including public CLI and nested/`Annotated` conversion behavior.
- Executable checked-in generated CLI, MCP, and FastAPI examples.
- Aligned contributor issue, PR, review, and changelog workflows.

## What this release PR changes

- Bumps the canonical package version from 0.7.1 to 0.7.2 using `uv version --bump patch`.
- Updates `uv.lock` from the same canonical version source.
- Assembles the four unreleased Towncrier fragments into the 0.7.2 changelog section.
- Consumes those four fragments.

## Verification

- `make check` — 486 tests passed; Ruff and Pyright passed.
- `bash scripts/demo.sh --no-save` — all supported conversions, dependency guards, generated CLI/MCP/FastAPI behavior, scaffolds, and atomic directory failure passed.
- Manual CI on exact pre-release `main`, including newest-resolvable dependencies — passed: https://github.com/tugrulguner/intpot/actions/runs/33175536215
- `uv build` — wheel and sdist built successfully.
- `twine check` — wheel and sdist passed.
- Wheel contents and sdist contents verified, including packaged templates and exclusion of contributor-only `AGENTS.md`.
- Clean wheel installs with `[all]` passed on Python 3.11, 3.12, 3.13, and 3.14.
- Each clean install verified metadata and `intpot --version`, compiled all three eject targets, invoked a generated Typer CLI, and called a generated FastAPI route with `TestClient`.
- `git diff --check` passed.

## Artifact hashes from local release-candidate build

- Wheel: `1ca111599d52c4e35deca155166c6e03909ccd1dcbeb19144120536ee9a5e1bb`
- Source distribution: `0a5a967a4ee38867b479640892025abe0bc772a329ff20ebeb0d3ed432325f28`

The release workflow will rebuild artifacts from the exact tag after this PR is merged and post-merge CI is green.
